### PR TITLE
[WIP] Added drawing namespace for simplifying complex CustomGrids.

### DIFF
--- a/Corale.Colore/Corale.Colore.csproj
+++ b/Corale.Colore/Corale.Colore.csproj
@@ -75,6 +75,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -94,6 +95,9 @@
     <Compile Include="Core\Mouse.cs" />
     <Compile Include="Core\NativeWrapper.cs" />
     <Compile Include="Core\Size.cs" />
+    <Compile Include="Drawing\ChromaGraphics.cs" />
+    <Compile Include="Drawing\ColorF.cs" />
+    <Compile Include="Drawing\Core.cs" />
     <Compile Include="Events\ApplicationStateEventArgs.cs" />
     <Compile Include="Events\SdkSupportEventArgs.cs" />
     <Compile Include="Native\Kernel32\NativeMethods.cs" />

--- a/Corale.Colore/Drawing/ChromaGraphics.cs
+++ b/Corale.Colore/Drawing/ChromaGraphics.cs
@@ -1,0 +1,316 @@
+﻿// ---------------------------------------------------------------------------------------
+// <copyright file="ChromaGraphics.cs" company="Corale">
+//     Copyright © 2015 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     Disclaimer: Corale and/or Colore is in no way affiliated with Razer and/or any
+//     of its employees and/or licensors. Corale, Adam Hellberg, and/or Brandon Scott
+//     do not take responsibility for any harm caused, direct or indirect, to any
+//     Razer peripherals via the use of Colore.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+// ---------------------------------------------------------------------------------------
+
+namespace Corale.Colore.Drawing
+{
+    using System;
+    using System.Drawing;
+
+    /// <summary>
+    ///     Class for drawing a complex grid to the keyboard.
+    /// </summary>
+    public partial class ChromaGraphics
+    {
+
+        /// <summary>
+        ///     Clear the keyboard to a color.
+        /// </summary>
+        /// <param name="color">The color to clear to.</param>
+        /// <param name="includeLogo">Whether to include the logo.</param>
+        public void Clear(ColorF color, bool includeLogo)
+        {
+            FillRectangle(color, 0, 0, Width, Height);
+            if (includeLogo)
+            {
+                SetLogoColor(color);
+            }
+        }
+
+        /// <summary>
+        ///     Clear the keyboard to a color without the logo.
+        /// </summary>
+        /// <param name="color">The color to clear to.</param>
+        public void Clear(ColorF color)
+        {
+            Clear(color, false);
+        }
+
+        /// <summary>
+        ///     Clear the keyboard to black.
+        /// </summary>
+        /// <param name="includeLogo"></param>
+        public void Clear(bool includeLogo)
+        {
+            Clear(new ColorF(0, 0, 0), includeLogo);
+        }
+
+        /// <summary>
+        ///     Clear the keyboard to black without the logo.
+        /// </summary>
+        public void Clear()
+        {
+            Clear(false);
+        }
+
+
+
+        /// <summary>
+        ///     Average all the pixels in an image to get a color.
+        /// </summary>
+        /// <param name="image">Image to average</param>
+        /// <returns>Average color found.</returns>
+        public ColorF GetAverageColor(Image image)
+        {
+            int size = image.Width * image.Height;
+            int a = 0;
+            int r = 0;
+            int g = 0;
+            int b = 0;
+
+            using (Bitmap map = new Bitmap(image))
+            {
+                for (int x = 0; x < map.Width; x++)
+                {
+                    for (int y = 0; y < map.Height; y++)
+                    {
+                        Color color = map.GetPixel(x, y);
+                        a += color.A;
+                        r += color.R;
+                        g += color.G;
+                        b += color.B;
+                    }
+                }
+            }
+
+            return new ColorF((a / 255f) / size, (r / 255f) / size, (g / 255f) / size, (b / 255f) / size);
+        }
+
+        /// <summary>
+        ///     Draws an image onto to the keyboard.
+        /// </summary>
+        /// <param name="image">Image to be drawn.</param>
+        /// <param name="x">X position of the image.</param>
+        /// <param name="y">Y position of the image.</param>
+        /// <param name="width">Width of the image to be drawn.</param>
+        /// <param name="height">Height of the image to be drawn.</param>
+        /// <param name="alpha">Alpha component all colors will be set to.</param>
+        public void DrawImage(Image image, int x, int y, int width, int height, float alpha)
+        {
+            if (width == 0 || height == 0) return;
+
+            using (Bitmap map = new Bitmap(image, width, height))
+            {
+                for (int xx = 0; xx < map.Width; xx++)
+                {
+                    for (int yy = 0; yy < map.Width; yy++)
+                    {
+                        SetColor(xx + x, yy + y, new ColorF(alpha, map.GetPixel(xx, yy)));
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Draws an image onto to the keyboard.
+        /// </summary>
+        /// <param name="image">Image to be drawn.</param>
+        /// <param name="x">X position of the image.</param>
+        /// <param name="y">Y position of the image.</param>
+        /// <param name="width">Width of the image to be drawn.</param>
+        /// <param name="height">Height of the image to be drawn.</param>
+        /// <param name="alpha">Alpha component all colors will be set to.</param>
+        public void DrawImage(Image image, float x, float y, float width, float height, float alpha)
+        {
+            int x1 = (int)Math.Round(x);
+            int y1 = (int)Math.Round(y);
+            int w = (int)Math.Round(width);
+            int h = (int)Math.Round(height);
+
+            DrawImage(image, x1, y1, w, h, alpha);
+        }
+
+        /// <summary>
+        ///     Draws an image onto to the keyboard.
+        /// </summary>
+        /// <param name="image">Image to be drawn.</param>
+        /// <param name="x">X position of the image.</param>
+        /// <param name="y">Y position of the image.</param>
+        /// <param name="width">Width of the image to be drawn.</param>
+        /// <param name="height">Height of the image to be drawn.</param>
+        public void DrawImage(Image image, int x, int y, int width, int height)
+        {
+            DrawImage(image, x, y, width, height, 1f);
+        }
+
+        /// <summary>
+        ///     Draws an image onto to the keyboard.
+        /// </summary>
+        /// <param name="image">Image to be drawn.</param>
+        /// <param name="x">X position of the image.</param>
+        /// <param name="y">Y position of the image.</param>
+        /// <param name="width">Width of the image to be drawn.</param>
+        /// <param name="height">Height of the image to be drawn.</param>
+        public void DrawImage(Image image, float x, float y, float width, float height)
+        {
+            DrawImage(image, x, y, width, height, 1f);
+        }
+
+        /// <summary>
+        ///     Draws an image onto to the keyboard with original size.
+        /// </summary>
+        /// <param name="image">Image to be drawn.</param>
+        /// <param name="x">X position of the image.</param>
+        /// <param name="y">Y position of the image.</param>
+        /// <param name="alpha">Alpha component all the colors will be set to.</param>
+        public void DrawImage(Image image, int x, int y, float alpha)
+        {
+            DrawImage(image, x, y, image.Width, image.Height, alpha);
+        }
+
+        /// <summary>
+        ///     Draws an image onto to the keyboard with original size.
+        /// </summary>
+        /// <param name="image">Image to be drawn.</param>
+        /// <param name="x">X position of the image.</param>
+        /// <param name="y">Y position of the image.</param>
+        /// <param name="alpha">Alpha component all the colors will be set to.</param>
+        public void DrawImage(Image image, float x, float y, float alpha)
+        {
+            DrawImage(image, x, y, image.Width, image.Height, alpha);
+        }
+
+        /// <summary>
+        ///     Draws an image onto to the keyboard with original size.
+        /// </summary>
+        /// <param name="image">Image to be drawn.</param>
+        /// <param name="x">X position of the image.</param>
+        /// <param name="y">Y position of the image.</param>
+        public void DrawImage(Image image, int x, int y)
+        {
+            DrawImage(image, x, y, 1f);
+        }
+
+        /// <summary>
+        ///     Draws an image onto to the keyboard with original size.
+        /// </summary>
+        /// <param name="image">Image to be drawn.</param>
+        /// <param name="x">X position of the image.</param>
+        /// <param name="y">Y position of the image.</param>
+        public void DrawImage(Image image, float x, float y)
+        {
+            int x1 = (int)Math.Round(x);
+            int y1 = (int)Math.Round(y);
+
+            DrawImage(image, x1, y1, 1f);
+        }
+
+
+
+        /// <summary>
+        ///     Draw the outline of a rectangle.
+        /// </summary>
+        /// <param name="color">Color of the rectangle.</param>
+        /// <param name="x">X position of the rectangle</param>
+        /// <param name="y">Y position of the rectangle</param>
+        /// <param name="width">Width of the rectangle.</param>
+        /// <param name="height">Height of the rectangle.</param>
+        public void DrawRectangle(ColorF color, int x, int y, int width, int height)
+        {
+            for (int xx = 0; xx < width; xx++)
+            {
+                for (int yy = 0; yy < height; yy++)
+                {
+                    if ((xx == 0 || xx == width - 1) || (yy == 0 || yy == height - 1))
+                    {
+                        SetColor(x + xx, y + yy, color);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Draw the outline of a rectangle.
+        /// </summary>
+        /// <param name="color">Color of the rectangle.</param>
+        /// <param name="x">X position of the rectangle</param>
+        /// <param name="y">Y position of the rectangle</param>
+        /// <param name="width">Width of the rectangle.</param>
+        /// <param name="height">Height of the rectangle.</param>
+        public void DrawRectangle(ColorF color, float x, float y, float width, float height)
+        {
+            int x1 = (int)Math.Round(x);
+            int y1 = (int)Math.Round(y);
+            int w = (int)Math.Round(width);
+            int h = (int)Math.Round(height);
+
+            this.DrawRectangle(color, x1, y1, w, h);
+        }
+
+
+        /// <summary>
+        ///     Draw a filled rectangle.
+        /// </summary>
+        /// <param name="color">Color of the rectangle.</param>
+        /// <param name="x">X position of the rectangle</param>
+        /// <param name="y">Y position of the rectangle</param>
+        /// <param name="width">Width of the rectangle.</param>
+        /// <param name="height">Height of the rectangle.</param>
+        public void FillRectangle(ColorF color, int x, int y, int width, int height)
+        {
+            for (int xx = 0; xx < width; xx++)
+            {
+                for (int yy = 0; yy < height; yy++)
+                {
+                    SetColor(x + xx, y + yy, color);
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Draw a filled rectangle.
+        /// </summary>
+        /// <param name="color">Color of the rectangle.</param>
+        /// <param name="x">X position of the rectangle</param>
+        /// <param name="y">Y position of the rectangle</param>
+        /// <param name="width">Width of the rectangle.</param>
+        /// <param name="height">Height of the rectangle.</param>
+        public void FillRectangle(ColorF color, float x, float y, float width, float height)
+        {
+            int x1 = (int)Math.Round(x);
+            int y1 = (int)Math.Round(y);
+            int w = (int)Math.Round(width);
+            int h = (int)Math.Round(height);
+
+            this.FillRectangle(color, x1, y1, w, h);
+        }
+
+
+    }
+}

--- a/Corale.Colore/Drawing/ColorF.cs
+++ b/Corale.Colore/Drawing/ColorF.cs
@@ -1,0 +1,275 @@
+﻿// ---------------------------------------------------------------------------------------
+// <copyright file="ColorF.cs" company="Corale">
+//     Copyright © 2015 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     Disclaimer: Corale and/or Colore is in no way affiliated with Razer and/or any
+//     of its employees and/or licensors. Corale, Adam Hellberg, and/or Brandon Scott
+//     do not take responsibility for any harm caused, direct or indirect, to any
+//     Razer peripherals via the use of Colore.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+// ---------------------------------------------------------------------------------------
+
+namespace Corale.Colore.Drawing
+{
+
+    /// <summary>
+    ///     Color system for a easier and more mathimatical way of interacting with color.
+    ///     This color system includes the alpha component (transparency).
+    /// </summary>
+    public struct ColorF
+    {
+
+        private float _a;
+        private float _r;
+        private float _g;
+        private float _b;
+
+        /// <summary>
+        ///     Construct a ARGB color.
+        /// </summary>
+        /// <param name="a">Alpha component.</param>
+        /// <param name="r">Red component.</param>
+        /// <param name="g">Green component.</param>
+        /// <param name="b">Blue component.</param>
+        public ColorF(float a, float r, float g, float b)
+        {
+            this._a = a;
+            this._r = r;
+            this._g = g;
+            this._b = b;
+        }
+
+        /// <summary>
+        ///     Construct a RGB color where A = 1.
+        /// </summary>
+        /// <param name="r">Red component.</param>
+        /// <param name="g">Green component.</param>
+        /// <param name="b">Blue component.</param>
+        public ColorF(float r, float g, float b)
+            : this(1f, r, g, b)
+        {
+        }
+
+        /// <summary>
+        ///     Construct a ARGB color from another ColorF with a different alpha.
+        ///     NOTE: This was created for chaining.
+        /// </summary>
+        /// <param name="a">Alpha component</param>
+        /// <param name="color"></param>
+        public ColorF(float a, ColorF color)
+            : this(a, color.R, color.G, color.B)
+        {
+        }
+
+        /// <summary>
+        ///     Construct from System.Drawing.Color with specific alpha.
+        /// </summary>
+        /// <param name="a">Alpha component.</param>
+        /// <param name="color"></param>
+        public ColorF(float a, System.Drawing.Color color)
+            : this(a, color.R / 255f, color.G / 255f, color.B / 255f)
+        {
+        }
+
+        /// <summary>
+        ///     Construct from System.Drawing.Color
+        /// </summary>
+        /// <param name="color"></param>
+        public ColorF(System.Drawing.Color color)
+            : this(color.A / 255f, color)
+        {
+        }
+
+        /// <summary>
+        ///     Construct from Corale.Colore.Core.Color with a specific alpha.
+        /// </summary>
+        /// <param name="a">Alpha component</param>
+        /// <param name="color"></param>
+        public ColorF(float a, Corale.Colore.Core.Color color)
+            : this(a, color.R / 255f, color.G / 255f, color.B / 255f)
+        {
+        }
+
+        /// <summary>
+        ///     Construct from Corale.Colore.Core.Color.
+        /// </summary>
+        /// <param name="color"></param>
+        public ColorF(Corale.Colore.Core.Color color)
+            : this(1, color)
+        {
+        }
+
+        /// <summary>
+        ///     Alpha component.
+        /// </summary>
+        public float A
+        {
+            get { return _a; }
+            set
+            {
+                _a = value;
+                if (_a > 1)
+                {
+                    _a = 1;
+                }
+                else if (_a < 0)
+                {
+                    _a = 0;
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Red component.
+        /// </summary>
+        public float R
+        {
+            get { return _r; }
+            set
+            {
+                _r = value;
+                if (_r > 1)
+                {
+                    _r = 1;
+                }
+                else if (_r < 0)
+                {
+                    _r = 0;
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Green component.
+        /// </summary>
+        public float G
+        {
+            get { return _g; }
+            set
+            {
+                _g = value;
+                if (_g > 1)
+                {
+                    _g = 1;
+                }
+                else if (_g < 0)
+                {
+                    _g = 0;
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Blue component.
+        /// </summary>
+        public float B
+        {
+            get { return _b; }
+            set
+            {
+                _b = value;
+                if (_b > 1)
+                {
+                    _b = 1;
+                }
+                else if (_b < 0)
+                {
+                    _b = 0;
+                }
+            }
+        }
+
+
+        /// <summary>
+        ///     Blend a color into this color by a factor of blend.
+        /// </summary>
+        /// <param name="blendTo">The color to blend with.</param>
+        /// <param name="blend">A normalized value that tells the blender how much of the other color there is.</param>
+        public ColorF Blend(ColorF blendTo, float blend)
+        {
+            float invBlend = 1 - blend;
+
+            float a = this._a * invBlend + blendTo.A * blend;
+            float r = this._r * invBlend + blendTo.R * blend;
+            float g = this._g * invBlend + blendTo.G * blend;
+            float b = this._b * invBlend + blendTo.B * blend;
+
+            return new ColorF(a, r, g, b);
+        }
+
+        /// <summary>
+        ///     Get the inverse of this color.
+        /// </summary>
+        /// <param name="includeAlpha">Whether the alpha should be inversed.</param>
+        /// <returns></returns>
+        public ColorF Inverse(bool includeAlpha)
+        {
+            if (includeAlpha)
+            {
+                return new ColorF(1 - _a, 1 - _r, 1 - _g, 1 - _b);
+            }
+            else
+            {
+                return new ColorF(_a, 1 - _r, 1 - _g, 1 - _b);
+            }
+        }
+
+        /// <summary>
+        ///     Get the inverse of the color. Alpha stays the same.
+        /// </summary>
+        /// <returns></returns>
+        public ColorF Inverse()
+        {
+            return Inverse(false);
+        }
+
+
+        /// <summary>
+        ///     Constructs a System.Drawing.Color from the ARGB components.
+        /// </summary>
+        /// <returns>System.Drawing.Color identical to this color.</returns>
+        public System.Drawing.Color ToSystemColor()
+        {
+            return System.Drawing.Color.FromArgb((int)(_a * 255), (int)(_r * 255), (int)(_g * 255), (int)(_b * 255));
+        }
+
+        /// <summary>
+        ///     Constructs a Corale.Colore.Core.Color from the RGB components.
+        /// </summary>
+        /// <returns>Corale.Colore.Core.Color identical to this color, minus the alpha.</returns>
+        public Corale.Colore.Core.Color ToColor()
+        {
+            return new Corale.Colore.Core.Color(_r, _g, _b);
+        }
+
+        /// <summary>
+        ///     Constructs a Corale.Colore.Core.Color from the RGB components
+        ///     and blends it to the blendTo color with the alpha.
+        /// </summary>
+        /// <param name="blendTo">The color to blend with.</param>
+        /// <returns>Corale.Colore.Core.Color identical to this color, blended with alpha.</returns>
+        public Corale.Colore.Core.Color ToColor(Corale.Colore.Core.Color blendTo)
+        {
+            return new ColorF(blendTo).Blend(this, this.A).ToColor();
+        }
+    }
+}

--- a/Corale.Colore/Drawing/Core.cs
+++ b/Corale.Colore/Drawing/Core.cs
@@ -1,0 +1,138 @@
+﻿// ---------------------------------------------------------------------------------------
+// <copyright file="Core.cs" company="Corale">
+//     Copyright © 2015 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     Disclaimer: Corale and/or Colore is in no way affiliated with Razer and/or any
+//     of its employees and/or licensors. Corale, Adam Hellberg, and/or Brandon Scott
+//     do not take responsibility for any harm caused, direct or indirect, to any
+//     Razer peripherals via the use of Colore.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+// ---------------------------------------------------------------------------------------
+
+namespace Corale.Colore.Drawing
+{
+    using System;
+
+    using Corale.Colore.Core;
+    using Corale.Colore.Razer.Keyboard;
+    using Corale.Colore.Razer.Keyboard.Effects;
+
+    /// <summary>
+    ///     Class for drawing a complex grid to the keyboard.
+    /// </summary>
+    public partial class ChromaGraphics
+    {
+
+        public const int LogoX = 20;
+        public const int LogoY = 0;
+
+        private Color[][] _grid;
+
+        public ChromaGraphics()
+        {
+            // Create the proper grid.
+            _grid = new Color[Constants.MaxRows][];
+            for (int i = 0; i < _grid.Length; i++)
+            {
+                _grid[i] = new Color[Constants.MaxColumns];
+                for (int j = 0; j < _grid[i].Length; j++)
+                {
+                    _grid[i][j] = Color.Black;
+                }
+            }
+        }
+
+
+        /// <summary>
+        ///     Width of the graphics object.
+        /// </summary>
+        public int Width
+        {
+            get { return _grid[0].Length; }
+        }
+
+        /// <summary>
+        ///     Height of the graphics object
+        /// </summary>
+        public int Height
+        {
+            get { return _grid.Length; }
+        }
+
+
+
+        /// <summary>
+        ///     Get the color of any key on the keyboard.
+        /// </summary>
+        /// <param name="x">X position of the key.</param>
+        /// <param name="y">Y position of the key</param>
+        /// <returns>The color of the key at that position.</returns>
+        public ColorF GetColor(int x, int y)
+        {
+            if ((x >= 0 && x < Width) && (y >= 0 && y < Height))
+            {
+                Color color = _grid[y][x];
+                return new ColorF(color);
+            }
+            else
+            {
+                throw new ArgumentException("The x or y component is out of range.");
+            }
+        }
+
+        /// <summary>
+        ///     Set the color of any key. Cannot set the logo color with this method.
+        /// </summary>
+        /// <param name="x">X position of the key</param>
+        /// <param name="y">Y position of the key</param>
+        /// <param name="color">Color the key will be set to.</param>
+        public void SetColor(int x, int y, ColorF color)
+        {
+            if ((x >= 0 && x < Width)
+                && (y >= 0 && y < Height)
+                && !(x == LogoX && y == LogoY)) // Do not override the logo with this method.
+            {
+
+                _grid[y][x] = color.ToColor(_grid[y][x]);
+            }
+        }
+
+        /// <summary>
+        ///     Set the color of the logo.
+        /// </summary>
+        /// <param name="color">Color the logo will be set to.</param>
+        public void SetLogoColor(ColorF color)
+        {
+            _grid[LogoY][LogoX] = color.ToColor(_grid[LogoY][LogoX]);
+        }
+
+
+
+        /// <summary>
+        ///     The grid effect that can be set on any keyboard.
+        /// </summary>
+        public CustomGrid Effect
+        {
+            get { return new CustomGrid(_grid); }
+        }
+    }
+}


### PR DESCRIPTION
This pull request simplifies rendering complex CustomGrids to the keyboard.

The namespace includes the ChromaGraphics object which acts like the System.Drawing.Graphics but for keyboard rendering. This also takes in account transparency within the ChromaGraphics object using the ColorF structure for colors. Building CustomGrids with this namespace is much more simple than modifying the CustomGrid itself.

There are a few more things I would like to add such as Gradients, but I would like some feedback and a possible addition to the Colore Library :smile:.