### PR TITLE
Support for converting Color to/from System.Drawing.Color

### DIFF
--- a/Corale.Colore.Tests/Corale.Colore.Tests.csproj
+++ b/Corale.Colore.Tests/Corale.Colore.Tests.csproj
@@ -72,6 +72,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -81,7 +82,7 @@
   <ItemGroup>
     <Compile Include="ColoreExceptionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Razer\ColorTests.cs" />
+    <Compile Include="Core\ColorTests.cs" />
     <Compile Include="Razer\NativeCallExceptionTests.cs" />
     <Compile Include="Razer\ResultTests.cs" />
     <Compile Include="Razer\SizeTests.cs" />

--- a/Corale.Colore.Tests/Core/ColorTests.cs
+++ b/Corale.Colore.Tests/Core/ColorTests.cs
@@ -28,7 +28,7 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------
 
-namespace Corale.Colore.Tests.Razer
+namespace Corale.Colore.Tests.Core
 {
     using Corale.Colore.Core;
 
@@ -203,6 +203,49 @@ namespace Corale.Colore.Tests.Razer
             Assert.AreNotEqual(A, b);
             Assert.False(A == b);
             Assert.True(A != b);
+        }
+
+        [Test]
+        public void ShouldConstructFromSystemColor()
+        {
+            var source = System.Drawing.Color.FromArgb(5, 10, 15);
+            var coloreColor = new Color(source);
+
+            Assert.AreEqual(source.R, coloreColor.R);
+            Assert.AreEqual(source.G, coloreColor.G);
+            Assert.AreEqual(source.B, coloreColor.B);
+        }
+
+        [Test]
+        public void ShouldConvertToSystemColor()
+        {
+            var coloreColor = new Color(1, 2, 4);
+            var systemColor = (System.Drawing.Color)coloreColor;
+
+            Assert.AreEqual(coloreColor.R, systemColor.R);
+            Assert.AreEqual(coloreColor.G, systemColor.G);
+            Assert.AreEqual(coloreColor.B, systemColor.B);
+        }
+
+        [Test]
+        public void ShouldConvertFromSystemColor()
+        {
+            var systemColor = System.Drawing.Color.FromArgb(5, 10, 15);
+            var coloreColor = (Color)systemColor;
+
+            Assert.AreEqual(systemColor.R, coloreColor.R);
+            Assert.AreEqual(systemColor.G, coloreColor.G);
+            Assert.AreEqual(systemColor.B, coloreColor.B);
+        }
+
+        [Test]
+        public void ShouldEqualSystemColorUsingOverload()
+        {
+            var coloreColor = new Color(1, 2, 3);
+            var systemColor = System.Drawing.Color.FromArgb(1, 2, 3);
+
+            Assert.True(coloreColor.Equals(systemColor));
+            Assert.AreEqual(coloreColor, systemColor);
         }
     }
 }

--- a/Corale.Colore/Colore.csproj.DotSettings
+++ b/Corale.Colore/Colore.csproj.DotSettings
@@ -1,2 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">Experimental</s:String></wpf:ResourceDictionary>

--- a/Corale.Colore/Corale.Colore.csproj
+++ b/Corale.Colore/Corale.Colore.csproj
@@ -75,6 +75,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Corale.Colore/Core/Color.cs
+++ b/Corale.Colore/Core/Color.cs
@@ -37,7 +37,7 @@ namespace Corale.Colore.Core
     /// Represents an RGB color.
     /// </summary>
     [StructLayout(LayoutKind.Sequential, Size = sizeof(uint))]
-    public struct Color : IEquatable<Color>, IEquatable<uint>
+    public struct Color : IEquatable<Color>, IEquatable<uint>, IEquatable<System.Drawing.Color>
     {
         /// <summary>
         /// Black color.
@@ -119,8 +119,8 @@ namespace Corale.Colore.Core
         /// <param name="green">The green component.</param>
         /// <param name="blue">The blue component.</param>
         public Color(byte red, byte green, byte blue)
+            : this(red + ((uint)green << 8) + ((uint)blue << 16))
         {
-            _value = red + ((uint)green << 8) + ((uint)blue << 16);
         }
 
         /// <summary>
@@ -151,6 +151,16 @@ namespace Corale.Colore.Core
         /// </remarks>
         public Color(double red, double green, double blue)
             : this((byte)(red * 255), (byte)(green * 255), (byte)(blue * 255))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Color" /> struct using
+        /// a <see cref="System.Drawing.Color" /> struct as the source.
+        /// </summary>
+        /// <param name="source">An instance of the <see cref="System.Drawing.Color" /> struct.</param>
+        public Color(System.Drawing.Color source)
+            : this(source.R, source.G, source.B)
         {
         }
 
@@ -200,17 +210,6 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
-        /// Checks <paramref name="left" /> and <paramref name="right" /> for equality.
-        /// </summary>
-        /// <param name="left">Left operand, an instance of the <see cref="Color" /> struct.</param>
-        /// <param name="right">Right operand, an <see cref="object" />.</param>
-        /// <returns><c>true</c> if the two instances are equal, <c>false</c> otherwise.</returns>
-        public static bool operator ==(Color left, object right)
-        {
-            return left.Equals(right);
-        }
-
-        /// <summary>
         /// Converts a <see cref="Color" /> struct to a <see cref="uint" />.
         /// </summary>
         /// <param name="color">The <see cref="Color" /> to convert.</param>
@@ -229,6 +228,50 @@ namespace Corale.Colore.Core
         public static implicit operator Color(uint value)
         {
             return new Color(value);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Color" /> struct to a <see cref="System.Drawing.Color" /> struct.
+        /// </summary>
+        /// <param name="color">The <see cref="Color" /> to convert.</param>
+        /// <returns>
+        /// An instance of <see cref="System.Drawing.Color" /> representing the
+        /// value of the <paramref name="color" /> argument.
+        /// </returns>
+        /// <remarks>
+        /// This is an explicit cast since casting a <see cref="System.Drawing.Color" /> struct to <see cref="Color" />
+        /// is explicit.
+        /// </remarks>
+        public static explicit operator System.Drawing.Color(Color color)
+        {
+            return System.Drawing.Color.FromArgb(color.R, color.G, color.B);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="System.Drawing.Color" /> struct to a <see cref="Color" /> struct.
+        /// </summary>
+        /// <param name="color">The <see cref="System.Drawing.Color" /> to convert.</param>
+        /// <returns>
+        /// An instance of <see cref="Color" /> representing the value of the <paramref name="color" /> argument.
+        /// </returns>
+        /// <remarks>
+        /// This is an explicit cast since the alpha component of the <see cref="System.Drawing.Color" />
+        /// struct is discarded.
+        /// </remarks>
+        public static explicit operator Color(System.Drawing.Color color)
+        {
+            return new Color(color.R, color.G, color.B);
+        }
+
+        /// <summary>
+        /// Checks <paramref name="left" /> and <paramref name="right" /> for equality.
+        /// </summary>
+        /// <param name="left">Left operand, an instance of the <see cref="Color" /> struct.</param>
+        /// <param name="right">Right operand, an <see cref="object" />.</param>
+        /// <returns><c>true</c> if the two instances are equal, <c>false</c> otherwise.</returns>
+        public static bool operator ==(Color left, object right)
+        {
+            return left.Equals(right);
         }
 
         /// <summary>
@@ -259,6 +302,9 @@ namespace Corale.Colore.Core
             if (other is uint)
                 return Equals((uint)other);
 
+            if (other is System.Drawing.Color)
+                return Equals((System.Drawing.Color)other);
+
             return false;
         }
 
@@ -282,6 +328,19 @@ namespace Corale.Colore.Core
         public bool Equals(uint other)
         {
             return _value.Equals(other);
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to an instance of a
+        /// <see cref="System.Drawing.Color" /> struct.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if the current object is equal to the <paramref name="other"/> parameter; otherwise, <c>false</c>.
+        /// </returns>
+        /// <param name="other">An instance of <see cref="System.Drawing.Color" /> to compare with this object.</param>
+        public bool Equals(System.Drawing.Color other)
+        {
+            return R == other.R && G == other.G && B == other.B;
         }
 
         /// <summary>


### PR DESCRIPTION
So far this only converts RGB values, alpha is ignored.

We need to figure out the best way to implement alpha compatibility (see #25).

This might also interest @xChris6041x.