### PR TITLE
More color support and added tests

### DIFF
--- a/Corale.Colore.Tests/Corale.Colore.Tests.csproj
+++ b/Corale.Colore.Tests/Corale.Colore.Tests.csproj
@@ -67,6 +67,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Moq">
+      <HintPath>..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>

--- a/Corale.Colore.Tests/Corale.Colore.Tests.csproj
+++ b/Corale.Colore.Tests/Corale.Colore.Tests.csproj
@@ -84,6 +84,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ColoreExceptionTests.cs" />
+    <Compile Include="Events\ApplicationStateEventArgsTests.cs" />
+    <Compile Include="Events\DeviceAccessEventArgsTests.cs" />
+    <Compile Include="Events\SdkSupportEventArgsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Core\ColorTests.cs" />
     <Compile Include="Razer\Keyboard\Effects\BreathingTests.cs" />

--- a/Corale.Colore.Tests/Corale.Colore.Tests.csproj
+++ b/Corale.Colore.Tests/Corale.Colore.Tests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Core\ColorTests.cs" />
     <Compile Include="Razer\Keyboard\Effects\BreathingTests.cs" />
+    <Compile Include="Razer\Keyboard\Effects\CustomGridTests.cs" />
     <Compile Include="Razer\Keyboard\Effects\CustomTests.cs" />
     <Compile Include="Razer\Keyboard\Effects\ReactiveTests.cs" />
     <Compile Include="Razer\Keyboard\Effects\StaticTests.cs" />

--- a/Corale.Colore.Tests/Corale.Colore.Tests.csproj
+++ b/Corale.Colore.Tests/Corale.Colore.Tests.csproj
@@ -85,6 +85,11 @@
     <Compile Include="ColoreExceptionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Razer\ColorTests.cs" />
+    <Compile Include="Razer\Keyboard\Effects\BreathingTests.cs" />
+    <Compile Include="Razer\Keyboard\Effects\CustomTests.cs" />
+    <Compile Include="Razer\Keyboard\Effects\ReactiveTests.cs" />
+    <Compile Include="Razer\Keyboard\Effects\StaticTests.cs" />
+    <Compile Include="Razer\Keyboard\Effects\WaveTests.cs" />
     <Compile Include="Razer\NativeCallExceptionTests.cs" />
     <Compile Include="Razer\ResultTests.cs" />
     <Compile Include="Razer\SizeTests.cs" />

--- a/Corale.Colore.Tests/Events/ApplicationStateEventArgsTests.cs
+++ b/Corale.Colore.Tests/Events/ApplicationStateEventArgsTests.cs
@@ -1,0 +1,50 @@
+﻿// ---------------------------------------------------------------------------------------
+// <copyright file="ApplicationStateEventArgsTests.cs" company="Corale">
+//     Copyright © 2015 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     Disclaimer: Corale and/or Colore is in no way affiliated with Razer and/or any
+//     of its employees and/or licensors. Corale, Adam Hellberg, and/or Brandon Scott
+//     do not take responsibility for any harm caused, direct or indirect, to any
+//     Razer peripherals via the use of Colore.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+// ---------------------------------------------------------------------------------------
+
+namespace Corale.Colore.Tests.Events
+{
+    using Corale.Colore.Events;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ApplicationStateEventArgsTests
+    {
+        [Test]
+        public void ShouldConstructWithProperProperties()
+        {
+            const bool Expected = true;
+
+            var args = new ApplicationStateEventArgs(Expected);
+
+            Assert.AreEqual(Expected, args.Enabled);
+        }
+    }
+}

--- a/Corale.Colore.Tests/Events/DeviceAccessEventArgsTests.cs
+++ b/Corale.Colore.Tests/Events/DeviceAccessEventArgsTests.cs
@@ -1,0 +1,48 @@
+﻿// ---------------------------------------------------------------------------------------
+// <copyright file="DeviceAccessEventArgsTests.cs" company="Corale">
+//     Copyright © 2015 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     Disclaimer: Corale and/or Colore is in no way affiliated with Razer and/or any
+//     of its employees and/or licensors. Corale, Adam Hellberg, and/or Brandon Scott
+//     do not take responsibility for any harm caused, direct or indirect, to any
+//     Razer peripherals via the use of Colore.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+// ---------------------------------------------------------------------------------------
+
+namespace Corale.Colore.Tests.Events
+{
+    using Corale.Colore.Events;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class DeviceAccessEventArgsTests
+    {
+        [Test]
+        public void ShouldConstructWithProperProperties()
+        {
+            const bool Expected = true;
+            var args = new DeviceAccessEventArgs(Expected);
+            Assert.AreEqual(Expected, args.Granted);
+        }
+    }
+}

--- a/Corale.Colore.Tests/Events/SdkSupportEventArgsTests.cs
+++ b/Corale.Colore.Tests/Events/SdkSupportEventArgsTests.cs
@@ -1,0 +1,48 @@
+﻿// ---------------------------------------------------------------------------------------
+// <copyright file="SdkSupportEventArgsTests.cs" company="Corale">
+//     Copyright © 2015 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     Disclaimer: Corale and/or Colore is in no way affiliated with Razer and/or any
+//     of its employees and/or licensors. Corale, Adam Hellberg, and/or Brandon Scott
+//     do not take responsibility for any harm caused, direct or indirect, to any
+//     Razer peripherals via the use of Colore.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+// ---------------------------------------------------------------------------------------
+
+namespace Corale.Colore.Tests.Events
+{
+    using Corale.Colore.Events;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class SdkSupportEventArgsTests
+    {
+        [Test]
+        public void ShouldConstructWithProperProperties()
+        {
+            const bool Expected = true;
+            var args = new SdkSupportEventArgs(Expected);
+            Assert.AreEqual(Expected, args.Enabled);
+        }
+    }
+}

--- a/Corale.Colore.Tests/Razer/Keyboard/Effects/BreathingTests.cs
+++ b/Corale.Colore.Tests/Razer/Keyboard/Effects/BreathingTests.cs
@@ -1,0 +1,53 @@
+﻿// ---------------------------------------------------------------------------------------
+// <copyright file="BreathingTests.cs" company="Corale">
+//     Copyright © 2015 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     Disclaimer: Corale and/or Colore is in no way affiliated with Razer and/or any
+//     of its employees and/or licensors. Corale, Adam Hellberg, and/or Brandon Scott
+//     do not take responsibility for any harm caused, direct or indirect, to any
+//     Razer peripherals via the use of Colore.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+// ---------------------------------------------------------------------------------------
+
+namespace Corale.Colore.Tests.Razer.Keyboard.Effects
+{
+    using Corale.Colore.Core;
+    using Corale.Colore.Razer.Keyboard.Effects;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class BreathingTests
+    {
+        [Test]
+        public void ShouldConstructWithCorrectFirstColor()
+        {
+            Assert.That(new Breathing(Color.Red, Color.Blue).First, Is.EqualTo(Color.Red));
+        }
+
+        [Test]
+        public void ShouldConstructWithCorrectSecondColor()
+        {
+            Assert.That(new Breathing(Color.Orange, Color.Purple).Second, Is.EqualTo(Color.Purple));
+        }
+    }
+}

--- a/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomGridTests.cs
+++ b/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomGridTests.cs
@@ -1,0 +1,332 @@
+﻿// ---------------------------------------------------------------------------------------
+// <copyright file="CustomGridTests.cs" company="Corale">
+//     Copyright © 2015 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     Disclaimer: Corale and/or Colore is in no way affiliated with Razer and/or any
+//     of its employees and/or licensors. Corale, Adam Hellberg, and/or Brandon Scott
+//     do not take responsibility for any harm caused, direct or indirect, to any
+//     Razer peripherals via the use of Colore.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+// ---------------------------------------------------------------------------------------
+
+namespace Corale.Colore.Tests.Razer.Keyboard.Effects
+{
+    using System;
+
+    using Corale.Colore.Core;
+    using Corale.Colore.Razer.Keyboard;
+    using Corale.Colore.Razer.Keyboard.Effects;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class CustomGridTests
+    {
+        [Test]
+        public void ShouldThrowWhenOutOfRangeGet()
+        {
+            var grid = CustomGrid.Create();
+
+            // ReSharper disable once NotAccessedVariable
+            Color dummy;
+
+            Assert.That(
+                () => dummy = grid[-1, 0],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("row")
+                      .And.Property("ActualValue")
+                      .EqualTo(-1));
+
+            Assert.That(
+                () => dummy = grid[(int)Constants.MaxRows + 1, 0],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("row")
+                      .And.Property("ActualValue")
+                      .EqualTo(Constants.MaxRows + 1));
+
+            Assert.That(
+                () => dummy = grid[0, -1],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("column")
+                      .And.Property("ActualValue")
+                      .EqualTo(-1));
+
+            Assert.That(
+                () => dummy = grid[0, (int)Constants.MaxColumns + 1],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("column")
+                      .And.Property("ActualValue")
+                      .EqualTo(Constants.MaxColumns + 1));
+        }
+
+        [Test]
+        public void ShouldThrowWhenOutOfRangeSet()
+        {
+            var grid = CustomGrid.Create();
+
+            Assert.That(
+                () => grid[-1, 0] = Color.Red,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("row")
+                      .And.Property("ActualValue")
+                      .EqualTo(-1));
+
+            Assert.That(
+                () => grid[(int)Constants.MaxRows + 1, 0] = Color.Red,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("row")
+                      .And.Property("ActualValue")
+                      .EqualTo(Constants.MaxRows + 1));
+
+            Assert.That(
+                () => grid[0, -1] = Color.Red,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("column")
+                      .And.Property("ActualValue")
+                      .EqualTo(-1));
+
+            Assert.That(
+                () => grid[0, (int)Constants.MaxColumns + 1] = Color.Red,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("column")
+                      .And.Property("ActualValue")
+                      .EqualTo(Constants.MaxColumns + 1));
+        }
+
+        [Test]
+        public void ShouldThrowWhenInvalidRowCount()
+        {
+            // We don't need to set up the columns as the code should throw before
+            // it reaches the point of iterating rows
+            var arr = new Color[2][];
+
+            // ReSharper disable once NotAccessedVariable
+            CustomGrid dummy;
+
+            Assert.That(
+                () => dummy = new CustomGrid(arr),
+                Throws.ArgumentException.With.Property("ParamName").EqualTo("colors"));
+        }
+
+        [Test]
+        public void ShouldThrowWhenInvalidColumnCount()
+        {
+            var arr = new Color[Constants.MaxRows][];
+
+            // We only need to populate one of the rows, as the
+            // code shouldn't check further anyway.
+            arr[0] = new Color[2];
+
+            // ReSharper disable once NotAccessedVariable
+            CustomGrid dummy;
+
+            Assert.That(
+                () => dummy = new CustomGrid(arr),
+                Throws.ArgumentException.With.Property("ParamName").EqualTo("colors"));
+        }
+
+        [Test]
+        public void ShouldSetToBlackWithCreate()
+        {
+            var grid = CustomGrid.Create();
+
+            for (var row = 0; row < Constants.MaxRows; row++)
+            {
+                for (var column = 0; column < Constants.MaxColumns; column++)
+                    Assert.That(grid[row, column], Is.EqualTo(Color.Black));
+            }
+        }
+
+        [Test]
+        public void ShouldSetAllColorsWithColorCtor()
+        {
+            var grid = new CustomGrid(Color.Red);
+
+            for (var row = 0; row < Constants.MaxRows; row++)
+            {
+                for (var column = 0; column < Constants.MaxColumns; column++)
+                    Assert.That(grid[row, column], Is.EqualTo(Color.Red));
+            }
+        }
+
+        [Test]
+        public void ShouldSetProperColorsWithArrCtor()
+        {
+            var arr = new Color[Constants.MaxRows][];
+
+            for (var row = 0; row < Constants.MaxRows; row++)
+                arr[row] = new Color[Constants.MaxColumns];
+
+            // Set some arbitrary colors to test
+            arr[0][5] = Color.Purple;
+            arr[2][3] = Color.Pink;
+            arr[4][0] = Color.Blue;
+
+            var grid = new CustomGrid(arr);
+
+            for (var row = 0; row < Constants.MaxRows; row++)
+            {
+                for (var col = 0; col < Constants.MaxColumns; col++)
+                    Assert.That(grid[row, col], Is.EqualTo(arr[row][col]));
+            }
+        }
+
+        [Test]
+        public void ShouldSetNewColors()
+        {
+            var grid = CustomGrid.Create();
+
+            grid[0, 5] = Color.Red;
+
+            Assert.That(grid[0, 5], Is.EqualTo(Color.Red));
+        }
+
+        [Test]
+        public void ShouldClearToBlack()
+        {
+            var grid = new CustomGrid(Color.Pink);
+            grid.Clear();
+
+            Assert.That(grid, Is.EqualTo(CustomGrid.Create()));
+        }
+
+        [Test]
+        public void ShouldEqualIdenticalGrid()
+        {
+            var a = new CustomGrid(Color.Red);
+            var b = new CustomGrid(Color.Red);
+
+            Assert.True(a == b);
+            Assert.False(a != b);
+            Assert.True(a.Equals(b));
+            Assert.AreEqual(a, b);
+        }
+
+        [Test]
+        public void ShouldNotEqualDifferentGrid()
+        {
+            var a = new CustomGrid(Color.Red);
+            var b = new CustomGrid(Color.Pink);
+
+            Assert.False(a == b);
+            Assert.True(a != b);
+            Assert.False(a.Equals(b));
+            Assert.AreNotEqual(a, b);
+        }
+
+        [Test]
+        public void ShouldEqualIdenticalArray()
+        {
+            var grid = new CustomGrid(Color.Red);
+            var arr = new Color[Constants.MaxRows][];
+
+            // Populate the 2D array
+            for (var row = 0; row < Constants.MaxRows; row++)
+            {
+                arr[row] = new Color[Constants.MaxColumns];
+                for (var col = 0; col < Constants.MaxColumns; col++)
+                    arr[row][col] = Color.Red;
+            }
+
+            Assert.True(grid == arr);
+            Assert.False(grid != arr);
+            Assert.True(grid.Equals(arr));
+            Assert.AreEqual(grid, arr);
+        }
+
+        [Test]
+        public void ShouldNotEqualDifferentArray()
+        {
+            var grid = new CustomGrid(Color.Pink);
+            var arr = new Color[Constants.MaxRows][];
+
+            // Populate the 2D array
+            for (var row = 0; row < Constants.MaxRows; row++)
+            {
+                arr[row] = new Color[Constants.MaxColumns];
+                for (var col = 0; col < Constants.MaxColumns; col++)
+                    arr[row][col] = Color.Red;
+            }
+
+            Assert.False(grid == arr);
+            Assert.True(grid != arr);
+            Assert.False(grid.Equals(arr));
+            Assert.AreNotEqual(grid, arr);
+        }
+
+        [Test]
+        public void ShouldNotEqualArrayWithInvalidRowCount()
+        {
+            var grid = CustomGrid.Create();
+            var arr = new Color[2][];
+
+            Assert.False(grid == arr);
+            Assert.True(grid != arr);
+            Assert.False(grid.Equals(arr));
+            Assert.AreNotEqual(grid, arr);
+        }
+
+        [Test]
+        public void ShouldNotEqualArrayWithInvalidColumnCount()
+        {
+            var grid = CustomGrid.Create();
+            var arr = new Color[Constants.MaxRows][];
+            arr[0] = new Color[2];
+
+            Assert.False(grid == arr);
+            Assert.True(grid != arr);
+            Assert.False(grid.Equals(arr));
+            Assert.AreNotEqual(grid, arr);
+        }
+
+        [Test]
+        public void ShouldNotEqualArbitraryObject()
+        {
+            var grid = CustomGrid.Create();
+            var obj = new object();
+
+            Assert.False(grid == obj);
+            Assert.True(grid != obj);
+            Assert.False(grid.Equals(obj));
+            Assert.AreNotEqual(grid, obj);
+        }
+
+        [Test]
+        public void ShouldNotEqualNull()
+        {
+            var grid = CustomGrid.Create();
+
+            Assert.False(grid == null);
+            Assert.True(grid != null);
+            Assert.False(grid.Equals(null));
+            Assert.AreNotEqual(grid, null);
+        }
+    }
+}

--- a/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
+++ b/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
@@ -1,0 +1,54 @@
+﻿// ---------------------------------------------------------------------------------------
+// <copyright file="CustomTests.cs" company="Corale">
+//     Copyright © 2015 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     Disclaimer: Corale and/or Colore is in no way affiliated with Razer and/or any
+//     of its employees and/or licensors. Corale, Adam Hellberg, and/or Brandon Scott
+//     do not take responsibility for any harm caused, direct or indirect, to any
+//     Razer peripherals via the use of Colore.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+// ---------------------------------------------------------------------------------------
+
+namespace Corale.Colore.Tests.Razer.Keyboard.Effects
+{
+    using Corale.Colore.Core;
+    using Corale.Colore.Razer.Keyboard;
+    using Corale.Colore.Razer.Keyboard.Effects;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class CustomTests
+    {
+        [Test]
+        public void ShouldConstructWithCorrectKey()
+        {
+            Assert.That(new Custom(Key.C, Color.Black).Key, Is.EqualTo(Key.C));
+        }
+
+        [Test]
+        public void ShouldConstructWithCorrectColor()
+        {
+            Assert.That(new Custom(Key.A, Color.Pink).Color, Is.EqualTo(Color.Pink));
+        }
+    }
+}

--- a/Corale.Colore.Tests/Razer/Keyboard/Effects/ReactiveTests.cs
+++ b/Corale.Colore.Tests/Razer/Keyboard/Effects/ReactiveTests.cs
@@ -1,0 +1,53 @@
+﻿// ---------------------------------------------------------------------------------------
+// <copyright file="ReactiveTests.cs" company="Corale">
+//     Copyright © 2015 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     Disclaimer: Corale and/or Colore is in no way affiliated with Razer and/or any
+//     of its employees and/or licensors. Corale, Adam Hellberg, and/or Brandon Scott
+//     do not take responsibility for any harm caused, direct or indirect, to any
+//     Razer peripherals via the use of Colore.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+// ---------------------------------------------------------------------------------------
+
+namespace Corale.Colore.Tests.Razer.Keyboard.Effects
+{
+    using Corale.Colore.Core;
+    using Corale.Colore.Razer.Keyboard.Effects;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ReactiveTests
+    {
+        [Test]
+        public void ShouldConstructWithCorrectColor()
+        {
+            Assert.That(new Reactive(Color.Red, Duration.Short).Color, Is.EqualTo(Color.Red));
+        }
+
+        [Test]
+        public void ShouldConstructWithCorrectDuration()
+        {
+            Assert.That(new Reactive(Color.Black, Duration.Medium).Duration, Is.EqualTo(Duration.Medium));
+        }
+    }
+}

--- a/Corale.Colore.Tests/Razer/Keyboard/Effects/StaticTests.cs
+++ b/Corale.Colore.Tests/Razer/Keyboard/Effects/StaticTests.cs
@@ -1,0 +1,47 @@
+﻿// ---------------------------------------------------------------------------------------
+// <copyright file="StaticTests.cs" company="Corale">
+//     Copyright © 2015 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     Disclaimer: Corale and/or Colore is in no way affiliated with Razer and/or any
+//     of its employees and/or licensors. Corale, Adam Hellberg, and/or Brandon Scott
+//     do not take responsibility for any harm caused, direct or indirect, to any
+//     Razer peripherals via the use of Colore.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+// ---------------------------------------------------------------------------------------
+
+namespace Corale.Colore.Tests.Razer.Keyboard.Effects
+{
+    using Corale.Colore.Core;
+    using Corale.Colore.Razer.Keyboard.Effects;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class StaticTests
+    {
+        [Test]
+        public void ShouldConstructWithCorrectColor()
+        {
+            Assert.That(new Static(Color.Red).Color, Is.EqualTo(Color.Red));
+        }
+    }
+}

--- a/Corale.Colore.Tests/Razer/Keyboard/Effects/WaveTests.cs
+++ b/Corale.Colore.Tests/Razer/Keyboard/Effects/WaveTests.cs
@@ -1,0 +1,46 @@
+﻿// ---------------------------------------------------------------------------------------
+// <copyright file="WaveTests.cs" company="Corale">
+//     Copyright © 2015 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     Disclaimer: Corale and/or Colore is in no way affiliated with Razer and/or any
+//     of its employees and/or licensors. Corale, Adam Hellberg, and/or Brandon Scott
+//     do not take responsibility for any harm caused, direct or indirect, to any
+//     Razer peripherals via the use of Colore.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+// ---------------------------------------------------------------------------------------
+
+namespace Corale.Colore.Tests.Razer.Keyboard.Effects
+{
+    using Corale.Colore.Razer.Keyboard.Effects;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class WaveTests
+    {
+        [Test]
+        public void ShouldConstructWithCorrectDirection()
+        {
+            Assert.That(new Wave(Direction.LeftToRight).Direction, Is.EqualTo(Direction.LeftToRight));
+        }
+    }
+}

--- a/Corale.Colore.Tests/packages.config
+++ b/Corale.Colore.Tests/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
@@ -165,6 +165,19 @@ namespace Corale.Colore.Razer.Keyboard.Effects
             }
 
             /// <summary>
+            /// Initializes a new instance of the <see cref="Row" /> struct
+            /// setting each column to a specific color.
+            /// </summary>
+            /// <param name="color">The <see cref="Color" /> to set each column to.</param>
+            internal Row(Color color)
+            {
+                Columns = new uint[Constants.MaxColumns];
+
+                for (var col = 0; col < (int)Constants.MaxColumns; col++)
+                    Columns[col] = color;
+            }
+
+            /// <summary>
             /// Converts an instance of the <see cref="Row" /> struct to an array of unsigned integers.
             /// </summary>
             /// <param name="row">The <see cref="Row" /> object to convert.</param>

--- a/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
@@ -102,10 +102,10 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         {
             get
             {
-                if (row >= Constants.MaxRows)
+                if (row < 0 || row >= Constants.MaxRows)
                     throw new ArgumentOutOfRangeException("row", row, "Attempted to access a row that does not exist.");
 
-                if (column >= Constants.MaxColumns)
+                if (column < 0 || column >= Constants.MaxColumns)
                 {
                     throw new ArgumentOutOfRangeException(
                         "column",
@@ -118,10 +118,10 @@ namespace Corale.Colore.Razer.Keyboard.Effects
 
             set
             {
-                if (row >= Constants.MaxRows)
+                if (row < 0 || row >= Constants.MaxRows)
                     throw new ArgumentOutOfRangeException("row", row, "Attempted to access a row that does not exist.");
 
-                if (column >= Constants.MaxColumns)
+                if (column < 0 || column >= Constants.MaxColumns)
                 {
                     throw new ArgumentOutOfRangeException(
                         "column",

--- a/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
@@ -100,7 +100,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
                         "Attempted to access a column that does not exist.");
                 }
 
-                return Rows[row].Columns[column];
+                return Rows[row][column];
             }
 
             set
@@ -116,7 +116,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
                         "Attempted to access a column that does not exist.");
                 }
 
-                Rows[row].Columns[column] = value;
+                Rows[row][column] = value;
             }
         }
 
@@ -129,7 +129,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
             {
                 var rowArr = Rows[row];
                 for (var col = 0; col < (int)Constants.MaxColumns; col++)
-                    rowArr.Columns[col] = Color.Black;
+                    rowArr[col] = Color.Black;
             }
         }
 

--- a/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
@@ -61,7 +61,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         /// <exception cref="ArgumentException">Thrown if the colors array supplied is of an incorrect size.</exception>
         public CustomGrid(Color[][] colors)
         {
-            var rows = (Size)colors.GetLength(0);
+            var rows = colors.GetLength(0);
 
             if (rows != Constants.MaxRows)
             {

--- a/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
@@ -50,9 +50,8 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         /// The array is 2-dimensional, with the first dimension
         /// specifying the row for the key, and the second the column.
         /// </remarks>
-        //[MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(NestedColorArrayMarshaler))]
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = (int)Constants.MaxRows)]
-        private readonly Row[] Rows;
+        private readonly Row[] _rows;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomGrid" /> struct.
@@ -70,12 +69,12 @@ namespace Corale.Colore.Razer.Keyboard.Effects
                     "colors");
             }
 
-            Rows = new Row[Constants.MaxRows];
+            _rows = new Row[Constants.MaxRows];
 
             for (Size row = 0; row < (int)Constants.MaxRows; row++)
             {
                 var inRow = colors[row];
-                Rows[row] = new Row(inRow);
+                _rows[row] = new Row(inRow);
             }
         }
 
@@ -86,10 +85,10 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         /// <param name="color">The <see cref="Color" /> to set each position to.</param>
         public CustomGrid(Color color)
         {
-            Rows = new Row[Constants.MaxRows];
+            _rows = new Row[Constants.MaxRows];
 
             for (var row = 0; row < Constants.MaxRows; row++)
-                Rows[row] = new Row(color);
+                _rows[row] = new Row(color);
         }
 
         /// <summary>
@@ -97,6 +96,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         /// </summary>
         /// <param name="row">Row to access, zero indexed.</param>
         /// <param name="column">Column to access, zero indexed.</param>
+        /// <returns>The <see cref="Color" /> at the specified position.</returns>
         [PublicAPI]
         public Color this[int row, int column]
         {
@@ -113,7 +113,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
                         "Attempted to access a column that does not exist.");
                 }
 
-                return Rows[row][column];
+                return _rows[row][column];
             }
 
             set
@@ -129,7 +129,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
                         "Attempted to access a column that does not exist.");
                 }
 
-                Rows[row][column] = value;
+                _rows[row][column] = value;
             }
         }
 
@@ -176,7 +176,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         /// <filterpriority>2</filterpriority>
         public override int GetHashCode()
         {
-            return Rows == null ? 0 : Rows.GetHashCode();
+            return _rows == null ? 0 : _rows.GetHashCode();
         }
 
         /// <summary>
@@ -186,7 +186,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         {
             for (var row = 0; row < (int)Constants.MaxRows; row++)
             {
-                var rowArr = Rows[row];
+                var rowArr = _rows[row];
                 for (var col = 0; col < (int)Constants.MaxColumns; col++)
                     rowArr[col] = Color.Black;
             }

--- a/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
@@ -134,6 +134,16 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         }
 
         /// <summary>
+        /// Creates a new empty <see cref="CustomGrid" /> struct.
+        /// </summary>
+        /// <returns>An instance of <see cref="CustomGrid" />
+        /// filled with the color black.</returns>
+        public static CustomGrid Create()
+        {
+            return new CustomGrid(Color.Black);
+        }
+
+        /// <summary>
         /// Clears the colors from the grid, setting them to <see cref="Color.Black" />.
         /// </summary>
         public void Clear()

--- a/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
@@ -80,6 +80,19 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CustomGrid" /> struct
+        /// with every position set to a specific color.
+        /// </summary>
+        /// <param name="color">The <see cref="Color" /> to set each position to.</param>
+        public CustomGrid(Color color)
+        {
+            Rows = new Row[Constants.MaxRows];
+
+            for (var row = 0; row < Constants.MaxRows; row++)
+                Rows[row] = new Row(color);
+        }
+
+        /// <summary>
         /// Gets or sets cells in the custom grid.
         /// </summary>
         /// <param name="row">Row to access, zero indexed.</param>

--- a/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
@@ -178,6 +178,40 @@ namespace Corale.Colore.Razer.Keyboard.Effects
             }
 
             /// <summary>
+            /// Gets or sets a column's <see cref="Color" />.
+            /// </summary>
+            /// <param name="column">The column index to access (zero-index).</param>
+            /// <returns>The <see cref="Color" /> at the specified column index.</returns>
+            internal Color this[int column]
+            {
+                get
+                {
+                    if (column < 0 || column >= Constants.MaxColumns)
+                    {
+                        throw new ArgumentOutOfRangeException(
+                            "column",
+                            column,
+                            "Attempted to access a column that does not exist.");
+                    }
+
+                    return Columns[column];
+                }
+
+                set
+                {
+                    if (column < 0 || column >= Constants.MaxColumns)
+                    {
+                        throw new ArgumentOutOfRangeException(
+                            "column",
+                            column,
+                            "Attempted to access a column that does not exist.");
+                    }
+
+                    Columns[column] = value;
+                }
+            }
+
+            /// <summary>
             /// Converts an instance of the <see cref="Row" /> struct to an array of unsigned integers.
             /// </summary>
             /// <param name="row">The <see cref="Row" /> object to convert.</param>

--- a/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
@@ -160,8 +160,8 @@ namespace Corale.Colore.Razer.Keyboard.Effects
 
                 Columns = new uint[Constants.MaxColumns];
 
-                for (var i = 0; i < (int)Constants.MaxColumns; i++)
-                    Columns[i] = colors[i];
+                for (var col = 0; col < (int)Constants.MaxColumns; col++)
+                    Columns[col] = colors[col];
             }
 
             /// <summary>

--- a/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/CustomGrid.cs
@@ -41,7 +41,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
     /// Describes a custom grid effect for every key.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public struct CustomGrid
+    public struct CustomGrid : IEquatable<CustomGrid>, IEquatable<Color[][]>
     {
         /// <summary>
         /// Color definitions for each key on the keyboard.
@@ -134,6 +134,30 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         }
 
         /// <summary>
+        /// Compares an instance of <see cref="CustomGrid" /> with
+        /// another object for equality.
+        /// </summary>
+        /// <param name="left">The left operand, an instance of <see cref="CustomGrid" />.</param>
+        /// <param name="right">The right operand, any type of object.</param>
+        /// <returns><c>true</c> if the two objects are equal, otherwise <c>false</c>.</returns>
+        public static bool operator ==(CustomGrid left, object right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Compares an instance of <see cref="CustomGrid" /> with
+        /// another object for inequality.
+        /// </summary>
+        /// <param name="left">The left operand, an instance of <see cref="CustomGrid" />.</param>
+        /// <param name="right">The right operand, any type of object.</param>
+        /// <returns><c>true</c> if the two objects are not equal, otherwise <c>false</c>.</returns>
+        public static bool operator !=(CustomGrid left, object right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <summary>
         /// Creates a new empty <see cref="CustomGrid" /> struct.
         /// </summary>
         /// <returns>An instance of <see cref="CustomGrid" />
@@ -141,6 +165,18 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         public static CustomGrid Create()
         {
             return new CustomGrid(Color.Black);
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A 32-bit signed integer that is the hash code for this instance.
+        /// </returns>
+        /// <filterpriority>2</filterpriority>
+        public override int GetHashCode()
+        {
+            return Rows == null ? 0 : Rows.GetHashCode();
         }
 
         /// <summary>
@@ -154,6 +190,80 @@ namespace Corale.Colore.Razer.Keyboard.Effects
                 for (var col = 0; col < (int)Constants.MaxColumns; col++)
                     rowArr[col] = Color.Black;
             }
+        }
+
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if <paramref name="obj"/> and this instance are of compatible types
+        /// and represent the same value; otherwise, <c>false</c>.
+        /// </returns>
+        /// <param name="obj">Another object to compare to. </param>
+        /// <filterpriority>2</filterpriority>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(obj, null))
+                return false;
+
+            if (obj is CustomGrid)
+                return Equals((CustomGrid)obj);
+
+            var arr = obj as Color[][];
+            return arr != null && Equals(arr);
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if the current object is equal to the <paramref name="other"/> parameter;
+        /// otherwise, <c>false</c>.
+        /// </returns>
+        /// <param name="other">A <see cref="CustomGrid" /> to compare with this object.</param>
+        public bool Equals(CustomGrid other)
+        {
+            for (var row = 0; row < Constants.MaxRows; row++)
+            {
+                for (var col = 0; col < Constants.MaxColumns; col++)
+                {
+                    if (this[row, col] != other[row, col])
+                        return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to an instance of
+        /// a 2-dimensional array of <see cref="Color" />.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if the <paramref name="other" /> object has the same
+        /// number of rows and columns, and contain matching colors; otherwise, <c>false</c>.
+        /// </returns>
+        /// <param name="other">
+        /// A 2-dimensional array of <see cref="Color" /> to compare with this object.
+        /// </param>
+        public bool Equals(Color[][] other)
+        {
+            if (other == null || other.GetLength(0) != Constants.MaxRows)
+                return false;
+
+            for (var row = 0; row < Constants.MaxRows; row++)
+            {
+                if (other[row].Length != Constants.MaxColumns)
+                    return false;
+
+                for (var col = 0; col < Constants.MaxColumns; col++)
+                {
+                    if (this[row, col] != other[row][col])
+                        return false;
+                }
+            }
+
+            return true;
         }
 
         /// <summary>
@@ -242,6 +352,18 @@ namespace Corale.Colore.Razer.Keyboard.Effects
             public static implicit operator uint[](Row row)
             {
                 return row.Columns;
+            }
+
+            /// <summary>
+            /// Returns the hash code for this instance.
+            /// </summary>
+            /// <returns>
+            /// A 32-bit signed integer that is the hash code for this instance.
+            /// </returns>
+            /// <filterpriority>2</filterpriority>
+            public override int GetHashCode()
+            {
+                return Columns == null ? 0 : Columns.GetHashCode();
             }
         }
     }

--- a/Corale.Colore/Razer/NativeMethods.cs
+++ b/Corale.Colore/Razer/NativeMethods.cs
@@ -482,9 +482,9 @@ namespace Corale.Colore.Razer
         /// Create keyboard effect.
         /// </summary>
         /// <param name="effect">
-        /// Standard effect type. These include <see cref="Keyboard.Effects.Effect.Wave" />,
-        /// <see cref="Keyboard.Effects.Effect.SpectrumCycling" />, <see cref="Keyboard.Effects.Effect.Breathing" />,
-        /// <see cref="Keyboard.Effects.Effect.Reactive" />, and <see cref="Keyboard.Effects.Effect.Static" />.
+        /// Standard effect type. These include <see cref="Razer.Keyboard.Effects.Effect.Wave" />,
+        /// <see cref="Razer.Keyboard.Effects.Effect.SpectrumCycling" />, <see cref="Razer.Keyboard.Effects.Effect.Breathing" />,
+        /// <see cref="Razer.Keyboard.Effects.Effect.Reactive" />, and <see cref="Razer.Keyboard.Effects.Effect.Static" />.
         /// </param>
         /// <param name="param">Pointer to a parameter type specified by <paramref name="effect" />.</param>
         /// <param name="effectid">Valid effect ID if successful. Use <see cref="Guid.Empty" /> if not required.</param>
@@ -498,24 +498,24 @@ namespace Corale.Colore.Razer
         /// <term>Effect struct</term>
         /// </listheader>
         /// <item>
-        /// <term><see cref="Keyboard.Effects.Effect.Wave" /></term>
-        /// <term><see cref="Keyboard.Effects.Wave" /></term>
+        /// <term><see cref="Razer.Keyboard.Effects.Effect.Wave" /></term>
+        /// <term><see cref="Razer.Keyboard.Effects.Wave" /></term>
         /// </item>
         /// <item>
-        /// <term><see cref="Keyboard.Effects.Effect.SpectrumCycling" /></term>
+        /// <term><see cref="Razer.Keyboard.Effects.Effect.SpectrumCycling" /></term>
         /// <term><i>None</i> (<see cref="IntPtr.Zero" />)</term>
         /// </item>
         /// <item>
-        /// <term><see cref="Keyboard.Effects.Effect.Breathing" /></term>
-        /// <term><see cref="Keyboard.Effects.Breathing" /></term>
+        /// <term><see cref="Razer.Keyboard.Effects.Effect.Breathing" /></term>
+        /// <term><see cref="Razer.Keyboard.Effects.Breathing" /></term>
         /// </item>
         /// <item>
-        /// <term><see cref="Keyboard.Effects.Effect.Reactive" /></term>
-        /// <term><see cref="Keyboard.Effects.Reactive" /></term>
+        /// <term><see cref="Razer.Keyboard.Effects.Effect.Reactive" /></term>
+        /// <term><see cref="Razer.Keyboard.Effects.Reactive" /></term>
         /// </item>
         /// <item>
-        /// <term><see cref="Keyboard.Effects.Effect.Static" /></term>
-        /// <term><see cref="Keyboard.Effects.Static" /></term>
+        /// <term><see cref="Razer.Keyboard.Effects.Effect.Static" /></term>
+        /// <term><see cref="Razer.Keyboard.Effects.Static" /></term>
         /// </item>
         /// </list>
         /// </remarks>
@@ -547,7 +547,7 @@ namespace Corale.Colore.Razer
         /// <param name="effects">Grid layout of the keyboard. Size is 6 rows by 22 columns.</param>
         /// <param name="effectId">Valid effect ID if successful. Pass <c>null</c> (<see cref="Guid.Empty" /> if not required.</param>
         /// <returns><see cref="Result" /> value indicating success.</returns>
-        /// <remarks>To turn all LEDs off, call with empty <see cref="Keyboard.Effects.CustomGrid" /> and a <c>ref</c> to <see cref="Guid.Empty" />.</remarks>
+        /// <remarks>To turn all LEDs off, call with empty <see cref="Razer.Keyboard.Effects.CustomGrid" /> and a <c>ref</c> to <see cref="Guid.Empty" />.</remarks>
         [DllImport(DllName, CallingConvention = FunctionConvention, EntryPoint = "CreateKeyboardCustomGridEffects",
             SetLastError = true)]
         internal static extern Result CreateKeyboardCustomGridEffects(
@@ -559,8 +559,8 @@ namespace Corale.Colore.Razer
         /// </summary>
         /// <param name="zone">The zone, or in this case LED, in which the effect is going to be applied.</param>
         /// <param name="effect">
-        /// Standard effect type. These include <see cref="Mouse.Effects.Effect.SpectrumCycling" />,
-        /// <see cref="Mouse.Effects.Effect.Breathing" />, and <see cref="Mouse.Effects.Effect.Static" />.
+        /// Standard effect type. These include <see cref="Razer.Mouse.Effects.Effect.SpectrumCycling" />,
+        /// <see cref="Razer.Mouse.Effects.Effect.Breathing" />, and <see cref="Razer.Mouse.Effects.Effect.Static" />.
         /// Depends on which LED.
         /// </param>
         /// <param name="param">Pointer to a parameter type specified by <paramref name="effect" />.</param>
@@ -575,20 +575,20 @@ namespace Corale.Colore.Razer
         /// <term>Effect struct</term>
         /// </listheader>
         /// <item>
-        /// <term><see cref="Mouse.Effects.Effect.SpectrumCycling" /></term>
+        /// <term><see cref="Razer.Mouse.Effects.Effect.SpectrumCycling" /></term>
         /// <term><i>None</i> (<see cref="IntPtr.Zero" />)</term>
         /// </item>
         /// <item>
-        /// <term><see cref="Mouse.Effects.Effect.Breathing" /></term>
-        /// <term><see cref="Mouse.Effects.Breathing" /></term>
+        /// <term><see cref="Razer.Mouse.Effects.Effect.Breathing" /></term>
+        /// <term><see cref="Razer.Mouse.Effects.Breathing" /></term>
         /// </item>
         /// <item>
-        /// <term><see cref="Mouse.Effects.Effect.Static" /></term>
-        /// <term><see cref="Mouse.Effects.Static" /></term>
+        /// <term><see cref="Razer.Mouse.Effects.Effect.Static" /></term>
+        /// <term><see cref="Razer.Mouse.Effects.Static" /></term>
         /// </item>
         /// <item>
-        /// <term><see cref="Mouse.Effects.Effect.Custom" /></term>
-        /// <term><see cref="Mouse.Effects.Custom" /></term>
+        /// <term><see cref="Razer.Mouse.Effects.Effect.Custom" /></term>
+        /// <term><see cref="Razer.Mouse.Effects.Custom" /></term>
         /// </item>
         /// </list>
         /// </remarks>


### PR DESCRIPTION
CustomGrid has a couple new methods for constructing grids with pre-populated colors.

 * A new overloaded constructor that takes a single color. This will set all keys to that color.
 * A new staic method `Create` that takes no parameters. This will create an empty `CustomGrid` (every color set to black).

Tests have been added for several classes, coverage as reported by dotCover in VS is now 64%(!).

Added `IEquatable` members to `CustomGrid`, it can now be compared to other `CustomGrid`s for equality and also to `Color[][]` 2D arrays.

Moq has been added as a NuGet reference but is not currently in use. Planned to be used for unit testing classes that are using the native wrapper.

This PR implements #26.