### PR TITLE
Integrate StyleCop with build process

### DIFF
--- a/Corale.Colore/Corale.Colore.csproj
+++ b/Corale.Colore/Corale.Colore.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>bad812f4</NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -177,6 +178,13 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Corale.Colore/Core/IMousepad.cs
+++ b/Corale.Colore/Core/IMousepad.cs
@@ -30,9 +30,8 @@
 
 namespace Corale.Colore.Core
 {
-    using Corale.Colore.Razer.Mousepad.Effects;
     using Corale.Colore.Annotations;
-    using Corale.Colore.Razer.Mousepad;
+    using Corale.Colore.Razer.Mousepad.Effects;
 
     /// <summary>
     /// Interface for mouse pad functionality.
@@ -43,24 +42,28 @@ namespace Corale.Colore.Core
         /// Sets a breathing effect on the mouse pad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Breathing" /> struct.</param>
+        [PublicAPI]
         void Set(Breathing effect);
 
         /// <summary>
         /// Sets a static color effect on the mouse pad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Static" /> struct.</param>
+        [PublicAPI]
         void Set(Static effect);
 
         /// <summary>
         /// Sets a wave effect on the mouse pad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Wave" /> struct.</param>
+        [PublicAPI]
         void Set(Wave effect);
 
         /// <summary>
         /// Sets a custom effect on the mouse pad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Custom" /> struct.</param>
+        [PublicAPI]
         void Set(Custom effect);
 
         /// <summary>

--- a/Corale.Colore/EnvironmentHelper.cs
+++ b/Corale.Colore/EnvironmentHelper.cs
@@ -32,7 +32,7 @@ namespace Corale.Colore
 {
     using System;
 
-    using Colore.Native.Kernel32;
+    using Corale.Colore.Native.Kernel32;
 
     /// <summary>
     /// Helper to get the architecture of the OS.
@@ -41,31 +41,26 @@ namespace Corale.Colore
     public static class EnvironmentHelper
     {
         /// <summary>
-        /// <returns>Returns true if the OS is 64-bit</returns>.
+        /// Determines whether the current system is 64-bit.
         /// </summary>
+        /// <returns><c>true</c> if the system is 64-bit.</returns>
         public static bool Is64BitOperatingSystem()
         {
-
             // Check if this process is natively an x64 process. If it is, it will only run on x64 environments, thus, the environment must be x64.
             if (IntPtr.Size == 8)
                 return true;
 
             // Check if this process is an x86 process running on an x64 environment.
-            IntPtr moduleHandle = NativeMethods.GetModuleHandle("kernel32");
-            if (moduleHandle != IntPtr.Zero)
-            {
-                IntPtr processAddress = NativeMethods.GetProcAddress(moduleHandle, "IsWow64Process");
-                if (processAddress != IntPtr.Zero)
-                {
-                    bool result;
-                    if (NativeMethods.IsWow64Process(NativeMethods.GetCurrentProcess(), out result) && result)
-                        return true;
-                }
-            }
+            var moduleHandle = NativeMethods.GetModuleHandle("kernel32");
+            if (moduleHandle == IntPtr.Zero)
+                return false;
 
-            // The environment must be an x86 environment.
-            return false;
+            var processAddress = NativeMethods.GetProcAddress(moduleHandle, "IsWow64Process");
+            if (processAddress == IntPtr.Zero)
+                return false;
+
+            bool result;
+            return NativeMethods.IsWow64Process(NativeMethods.GetCurrentProcess(), out result) && result;
         }
-
     }
 }

--- a/Corale.Colore/Settings.StyleCop
+++ b/Corale.Colore/Settings.StyleCop
@@ -40,5 +40,15 @@
       </Rules>
       <AnalyzerSettings />
     </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.DocumentationRules">
+      <Rules>
+        <Rule Name="ElementDocumentationMustBeSpelledCorrectly">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
   </Analyzers>
 </StyleCopSettings>

--- a/Corale.Colore/packages.config
+++ b/Corale.Colore/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="log4net" version="2.0.3" targetFramework="net35" />
+  <package id="StyleCop.MSBuild" version="4.7.49.1" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
The StyleCop.MSBuild NuGet package has been added which will automatically perform a StyleCop scan when the project is built anywhere.

By default, the violations will output as build warnings. The CI is currently configured to treat them as errors. Globally recognizing them as errors everywhere may not be desirable as developers will not be able to test any code locally if there are StyleCop violations left unfixed.

This also fixes some violations leftover from the last PR.