### PR TITLE
Refactor Set Methods

### DIFF
--- a/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
+++ b/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
@@ -184,7 +184,7 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
             for (var row = 0; row < Constants.MaxRows; row++)
                 arr[row] = new Color[Constants.MaxColumns];
 
-            // Set some arbitrary colors to test
+            // SetGuid some arbitrary colors to test
             arr[0][5] = Color.Purple;
             arr[2][3] = Color.Pink;
             arr[4][0] = Color.Blue;

--- a/Corale.Colore/Corale.Colore.csproj
+++ b/Corale.Colore/Corale.Colore.csproj
@@ -94,7 +94,10 @@
     <Compile Include="Core\Chroma.cs" />
     <Compile Include="Core\Color.cs" />
     <Compile Include="Core\Device.cs" />
+    <Compile Include="Core\SimpleHeadset.cs" />
     <Compile Include="Core\SimpleKeyboard.cs" />
+    <Compile Include="Core\SimpleKeypad.cs" />
+    <Compile Include="Core\SimpleMouse.cs" />
     <Compile Include="Core\SimpleMousepad.cs" />
     <Compile Include="EnvironmentHelper.cs" />
     <Compile Include="Core\GenericDevice.cs" />

--- a/Corale.Colore/Corale.Colore.csproj
+++ b/Corale.Colore/Corale.Colore.csproj
@@ -81,7 +81,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
+    <Reference Include="System.Drawing">
+      <HintPath>C:\Windows\Microsoft.NET\Framework\v2.0.50727\System.Drawing.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Data" />
@@ -92,6 +94,8 @@
     <Compile Include="Core\Chroma.cs" />
     <Compile Include="Core\Color.cs" />
     <Compile Include="Core\Device.cs" />
+    <Compile Include="Core\SimpleKeyboard.cs" />
+    <Compile Include="Core\SimpleMousepad.cs" />
     <Compile Include="EnvironmentHelper.cs" />
     <Compile Include="Core\GenericDevice.cs" />
     <Compile Include="Core\Headset.cs" />

--- a/Corale.Colore/Core/Device.cs
+++ b/Corale.Colore/Core/Device.cs
@@ -60,7 +60,7 @@ namespace Corale.Colore.Core
         /// Updates the device to use the effect pointed to by the specified GUID.
         /// </summary>
         /// <param name="guid">GUID to set.</param>
-        public void Set(Guid guid)
+        public void SetGuid(Guid guid)
         {
             if (CurrentEffectId != Guid.Empty)
             {

--- a/Corale.Colore/Core/Device.cs
+++ b/Corale.Colore/Core/Device.cs
@@ -47,14 +47,14 @@ namespace Corale.Colore.Core
         /// </summary>
         public void Clear()
         {
-            Set(Color.Black);
+            SetAllKeysColor(Color.Black);
         }
 
         /// <summary>
         /// Sets the color of all components on this device.
         /// </summary>
         /// <param name="color">Color to set.</param>
-        public abstract void Set(Color color);
+        public abstract void SetAllKeysColor(Color color);
 
         /// <summary>
         /// Updates the device to use the effect pointed to by the specified GUID.

--- a/Corale.Colore/Core/Device.cs
+++ b/Corale.Colore/Core/Device.cs
@@ -47,14 +47,14 @@ namespace Corale.Colore.Core
         /// </summary>
         public void Clear()
         {
-            SetAllKeysColor(Color.Black);
+            SetAll(Color.Black);
         }
 
         /// <summary>
         /// Sets the color of all components on this device.
         /// </summary>
         /// <param name="color">Color to set.</param>
-        public abstract void SetAllKeysColor(Color color);
+        public abstract void SetAll(Color color);
 
         /// <summary>
         /// Updates the device to use the effect pointed to by the specified GUID.

--- a/Corale.Colore/Core/GenericDevice.cs
+++ b/Corale.Colore/Core/GenericDevice.cs
@@ -105,7 +105,7 @@ namespace Corale.Colore.Core
         /// Sets the color of all components on this device.
         /// </summary>
         /// <param name="color">Color to set.</param>
-        public override void Set(Color color)
+        public override void SetAll(Color color)
         {
             var colorPtr = Marshal.AllocHGlobal(Marshal.SizeOf(color));
             Marshal.StructureToPtr(color, colorPtr, false);

--- a/Corale.Colore/Core/GenericDevice.cs
+++ b/Corale.Colore/Core/GenericDevice.cs
@@ -124,9 +124,9 @@ namespace Corale.Colore.Core
         /// Sets a parameter-less effect on this device.
         /// </summary>
         /// <param name="effect">Effect to set.</param>
-        public void Set(Effect effect)
+        public void SetEffect(Effect effect)
         {
-            Set(effect, IntPtr.Zero);
+            SetEffect(effect, IntPtr.Zero);
         }
 
         /// <summary>
@@ -134,7 +134,7 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="effect">Effect to set.</param>
         /// <param name="param">Effect-specific parameter to use.</param>
-        public void Set(Effect effect, IntPtr param)
+        public void SetEffect(Effect effect, IntPtr param)
         {
             SetGuid(NativeWrapper.CreateEffect(DeviceId, effect, param));
         }

--- a/Corale.Colore/Core/GenericDevice.cs
+++ b/Corale.Colore/Core/GenericDevice.cs
@@ -112,7 +112,7 @@ namespace Corale.Colore.Core
 
             try
             {
-                Set(NativeWrapper.CreateEffect(DeviceId, Effect.Static, colorPtr));
+                SetGuid(NativeWrapper.CreateEffect(DeviceId, Effect.Static, colorPtr));
             }
             finally
             {
@@ -136,7 +136,7 @@ namespace Corale.Colore.Core
         /// <param name="param">Effect-specific parameter to use.</param>
         public void Set(Effect effect, IntPtr param)
         {
-            Set(NativeWrapper.CreateEffect(DeviceId, effect, param));
+            SetGuid(NativeWrapper.CreateEffect(DeviceId, effect, param));
         }
     }
 }

--- a/Corale.Colore/Core/Headset.cs
+++ b/Corale.Colore/Core/Headset.cs
@@ -86,7 +86,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">The type of effect to set.</param>
         public void Set(Effect effect)
         {
-            Set(NativeWrapper.CreateHeadsetEffect(effect));
+            SetGuid(NativeWrapper.CreateHeadsetEffect(effect));
         }
 
         /// <summary>
@@ -98,7 +98,7 @@ namespace Corale.Colore.Core
         /// </param>
         public void Set(Static effect)
         {
-            Set(NativeWrapper.CreateHeadsetEffect(effect));
+            SetGuid(NativeWrapper.CreateHeadsetEffect(effect));
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace Corale.Colore.Core
         /// </param>
         public void Set(Breathing effect)
         {
-            Set(NativeWrapper.CreateHeadsetEffect(effect));
+            SetGuid(NativeWrapper.CreateHeadsetEffect(effect));
         }
     }
 }

--- a/Corale.Colore/Core/Headset.cs
+++ b/Corale.Colore/Core/Headset.cs
@@ -73,7 +73,7 @@ namespace Corale.Colore.Core
         /// Sets the color of all components on this device.
         /// </summary>
         /// <param name="color">Color to set.</param>
-        public override void Set(Color color)
+        public override void SetAll(Color color)
         {
             Set(new Static(color));
         }

--- a/Corale.Colore/Core/IDevice.cs
+++ b/Corale.Colore/Core/IDevice.cs
@@ -63,6 +63,6 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="guid">GUID to set.</param>
         [PublicAPI]
-        void Set(Guid guid);
+        void SetGuid(Guid guid);
     }
 }

--- a/Corale.Colore/Core/IDevice.cs
+++ b/Corale.Colore/Core/IDevice.cs
@@ -56,7 +56,7 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="color">Color to set.</param>
         [PublicAPI]
-        void Set(Color color);
+        void SetAllKeysColor(Color color);
 
         /// <summary>
         /// Updates the device to use the effect pointed to by the specified GUID.

--- a/Corale.Colore/Core/IDevice.cs
+++ b/Corale.Colore/Core/IDevice.cs
@@ -56,7 +56,7 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="color">Color to set.</param>
         [PublicAPI]
-        void SetAllKeysColor(Color color);
+        void SetAll(Color color);
 
         /// <summary>
         /// Updates the device to use the effect pointed to by the specified GUID.

--- a/Corale.Colore/Core/IGenericDevice.cs
+++ b/Corale.Colore/Core/IGenericDevice.cs
@@ -48,13 +48,13 @@ namespace Corale.Colore.Core
         /// Sets a parameter-less effect on this device.
         /// </summary>
         /// <param name="effect">Effect to set.</param>
-        void Set(Effect effect);
+        void SetEffect(Effect effect);
 
         /// <summary>
         /// Sets an effect on this device, taking a parameter.
         /// </summary>
         /// <param name="effect">Effect to set.</param>
         /// <param name="param">Effect-specific parameter to use.</param>
-        void Set(Effect effect, IntPtr param);
+        void SetEffect(Effect effect, IntPtr param);
     }
 }

--- a/Corale.Colore/Core/IHeadset.cs
+++ b/Corale.Colore/Core/IHeadset.cs
@@ -43,7 +43,7 @@ namespace Corale.Colore.Core
         /// for the <see cref="Effect.SpectrumCycling" /> effect.
         /// </summary>
         /// <param name="effect">The type of effect to set.</param>
-        void Set(Effect effect);
+        void SetEffect(Effect effect);
 
         /// <summary>
         /// Sets a new static effect on the headset.
@@ -52,7 +52,7 @@ namespace Corale.Colore.Core
         /// An instance of the <see cref="Static" /> struct
         /// describing the effect.
         /// </param>
-        void Set(Static effect);
+        void SetStatic(Static effect);
 
         /// <summary>
         /// Sets a new breathing effect on the headset.
@@ -61,6 +61,6 @@ namespace Corale.Colore.Core
         /// An instance of the <see cref="Breathing" /> struct
         /// describing the effect.
         /// </param>
-        void Set(Breathing effect);
+        void SetBreathing(Breathing effect);
     }
 }

--- a/Corale.Colore/Core/IKeyboard.cs
+++ b/Corale.Colore/Core/IKeyboard.cs
@@ -72,7 +72,7 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="effect">Effect options.</param>
         [PublicAPI]
-        void SetBreathingEffect(Breathing effect);
+        void SetBreathing(Breathing effect);
 
         /// <summary>
         /// Sets a breathing effect on the keyboard, fading between the

--- a/Corale.Colore/Core/IKeyboard.cs
+++ b/Corale.Colore/Core/IKeyboard.cs
@@ -72,7 +72,7 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="effect">Effect options.</param>
         [PublicAPI]
-        void Set(Breathing effect);
+        void SetBreathingEffect(Breathing effect);
 
         /// <summary>
         /// Sets a breathing effect on the keyboard, fading between the
@@ -81,7 +81,7 @@ namespace Corale.Colore.Core
         /// <param name="first">Color to start from.</param>
         /// <param name="second">Color to reach, before going back to <paramref name="first" />.</param>
         [PublicAPI]
-        void Set(Color first, Color second);
+        void SetBreathingColors(Color first, Color second);
 
         /// <summary>
         /// Sets a reactive effect on the keyboard with the specified
@@ -90,7 +90,7 @@ namespace Corale.Colore.Core
         /// <param name="color">Color to emit on key press.</param>
         /// <param name="duration">How long to illuminate the key after being pressed.</param>
         [PublicAPI]
-        void Set(Color color, Duration duration);
+        void SetReactive(Color color, Duration duration);
 
         /// <summary>
         /// Sets a custom grid effect on the keyboard using
@@ -105,7 +105,7 @@ namespace Corale.Colore.Core
         /// struct in the <see cref="Keyboard" /> class.
         /// </remarks>
         [PublicAPI]
-        void Set(Color[][] colors);
+        void SetCustomGrid(Color[][] colors);
 
         /// <summary>
         /// Sets a custom grid effect on the keyboard.
@@ -116,14 +116,14 @@ namespace Corale.Colore.Core
         /// struct in the <see cref="Keyboard" /> class.
         /// </remarks>
         [PublicAPI]
-        void Set(Custom effect);
+        void SetCustom(Custom effect);
 
         /// <summary>
         /// Sets a wave effect on the keyboard in the specified direction.
         /// </summary>
         /// <param name="direction">Direction of the wave.</param>
         [PublicAPI]
-        void Set(Direction direction);
+        void SetWaveWithDirection(Direction direction);
 
         /// <summary>
         /// Sets an effect without any parameters.
@@ -131,7 +131,7 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="effect">Effect options.</param>
         [PublicAPI]
-        void Set(Effect effect);
+        void SetEffect(Effect effect);
 
         /// <summary>
         /// Sets the color on a specific row and column on the keyboard grid.
@@ -141,7 +141,7 @@ namespace Corale.Colore.Core
         /// <param name="color">Color to set.</param>
         /// <param name="clear">Whether or not to clear the existing colors before setting this one.</param>
         [PublicAPI]
-        void Set(Size row, Size column, Color color, bool clear = false);
+        void SetPosition(Size row, Size column, Color color, bool clear = false);
 
         /// <summary>
         /// Sets the color of a specific key on the keyboard.
@@ -150,7 +150,7 @@ namespace Corale.Colore.Core
         /// <param name="color">Color to set.</param>
         /// <param name="clear">If <c>true</c>, the keyboard will first be cleared before setting the key.</param>
         [PublicAPI]
-        void Set(Key key, Color color, bool clear = false);
+        void SetKeyColor(Key key, Color color, bool clear = false);
 
         /// <summary>
         /// Sets the specified color on a set of keys.
@@ -159,7 +159,7 @@ namespace Corale.Colore.Core
         /// <param name="key">First key to change.</param>
         /// <param name="keys">Additional keys that should also have the color applied.</param>
         [PublicAPI]
-        void Set(Color color, Key key, params Key[] keys);
+        void SetKeyGroupColor(Color color, Key key, params Key[] keys);
 
         /// <summary>
         /// Sets a color on a collection of keys.
@@ -168,27 +168,27 @@ namespace Corale.Colore.Core
         /// <param name="color">The <see cref="Color" /> to apply.</param>
         /// <param name="clear">If <c>true</c>, the keyboard will first be cleared before setting the keys.</param>
         [PublicAPI]
-        void Set(IEnumerable<Key> keys, Color color, bool clear = false);
+        void SetKeyGroupColor(IEnumerable<Key> keys, Color color, bool clear = false);
 
         /// <summary>
         /// Sets a reactive effect on the keyboard.
         /// </summary>
         /// <param name="effect">Effect options.</param>
         [PublicAPI]
-        void Set(Reactive effect);
+        void SetReactive(Reactive effect);
 
         /// <summary>
         /// Sets a static color on the keyboard.
         /// </summary>
         /// <param name="effect">Effect options.</param>
         [PublicAPI]
-        void Set(Static effect);
+        void SetStatic(Static effect);
 
         /// <summary>
         /// Sets a wave effect on the keyboard.
         /// </summary>
         /// <param name="effect">Effect options.</param>
         [PublicAPI]
-        void Set(Wave effect);
+        void SetWave(Wave effect);
     }
 }

--- a/Corale.Colore/Core/IKeyboard.cs
+++ b/Corale.Colore/Core/IKeyboard.cs
@@ -123,7 +123,7 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="direction">Direction of the wave.</param>
         [PublicAPI]
-        void SetWaveWithDirection(Direction direction);
+        void SetWave(Direction direction);
 
         /// <summary>
         /// Sets an effect without any parameters.
@@ -150,7 +150,7 @@ namespace Corale.Colore.Core
         /// <param name="color">Color to set.</param>
         /// <param name="clear">If <c>true</c>, the keyboard will first be cleared before setting the key.</param>
         [PublicAPI]
-        void SetKeyColor(Key key, Color color, bool clear = false);
+        void SetKey(Key key, Color color, bool clear = false);
 
         /// <summary>
         /// Sets the specified color on a set of keys.
@@ -159,7 +159,7 @@ namespace Corale.Colore.Core
         /// <param name="key">First key to change.</param>
         /// <param name="keys">Additional keys that should also have the color applied.</param>
         [PublicAPI]
-        void SetKeyGroupColor(Color color, Key key, params Key[] keys);
+        void SetKeyGroup(Color color, Key key, params Key[] keys);
 
         /// <summary>
         /// Sets a color on a collection of keys.
@@ -168,7 +168,7 @@ namespace Corale.Colore.Core
         /// <param name="color">The <see cref="Color" /> to apply.</param>
         /// <param name="clear">If <c>true</c>, the keyboard will first be cleared before setting the keys.</param>
         [PublicAPI]
-        void SetKeyGroupColor(IEnumerable<Key> keys, Color color, bool clear = false);
+        void SetKeyGroup(IEnumerable<Key> keys, Color color, bool clear = false);
 
         /// <summary>
         /// Sets a reactive effect on the keyboard.

--- a/Corale.Colore/Core/IKeypad.cs
+++ b/Corale.Colore/Core/IKeypad.cs
@@ -54,35 +54,35 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Breathing" /> struct.</param>
         [PublicAPI]
-        void Set(Breathing effect);
+        void SetBreathing(Breathing effect);
 
         /// <summary>
         /// Sets a <see cref="Custom" /> effect on the keypad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Custom" /> struct.</param>
         [PublicAPI]
-        void Set(Custom effect);
+        void SetCustom(Custom effect);
 
         /// <summary>
         /// Sets a <see cref="Reactive" /> effect on the keypad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Reactive" /> struct.</param>
         [PublicAPI]
-        void Set(Reactive effect);
+        void SetReactive(Reactive effect);
 
         /// <summary>
         /// Sets a <see cref="Static" /> effect on the keypad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Static" /> struct.</param>
         [PublicAPI]
-        void Set(Static effect);
+        void SetStatic(Static effect);
 
         /// <summary>
         /// Sets a <see cref="Wave" /> effect on the keypad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Wave" /> struct.</param>
         [PublicAPI]
-        void Set(Wave effect);
+        void SetWave(Wave effect);
 
         /// <summary>
         /// Sets an effect without any parameters.
@@ -90,6 +90,6 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="effect">Effect options.</param>
         [PublicAPI]
-        void Set(Effect effect);
+        void SetEffect(Effect effect);
     }
 }

--- a/Corale.Colore/Core/IMousepad.cs
+++ b/Corale.Colore/Core/IMousepad.cs
@@ -43,28 +43,28 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Breathing" /> struct.</param>
         [PublicAPI]
-        void Set(Breathing effect);
+        void SetBreathing(Breathing effect);
 
         /// <summary>
         /// Sets a static color effect on the mouse pad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Static" /> struct.</param>
         [PublicAPI]
-        void Set(Static effect);
+        void SetStatic(Static effect);
 
         /// <summary>
         /// Sets a wave effect on the mouse pad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Wave" /> struct.</param>
         [PublicAPI]
-        void Set(Wave effect);
+        void SetWave(Wave effect);
 
         /// <summary>
         /// Sets a custom effect on the mouse pad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Custom" /> struct.</param>
         [PublicAPI]
-        void Set(Custom effect);
+        void SetCustom(Custom effect);
 
         /// <summary>
         /// Sets an effect without any parameters.
@@ -72,6 +72,6 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="effect">Effect options.</param>
         [PublicAPI]
-        void Set(Effect effect);
+        void SetEffect(Effect effect);
     }
 }

--- a/Corale.Colore/Core/Keyboard.cs
+++ b/Corale.Colore/Core/Keyboard.cs
@@ -30,14 +30,12 @@
 
 namespace Corale.Colore.Core
 {
-    using System;
-    using System.Collections.Generic;
-
     using Corale.Colore.Annotations;
     using Corale.Colore.Razer.Keyboard;
     using Corale.Colore.Razer.Keyboard.Effects;
-
     using log4net;
+    using System;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Class for interacting with a Chroma keyboard.
@@ -145,7 +143,7 @@ namespace Corale.Colore.Core
         /// Sets a breathing effect on the keyboard.
         /// </summary>
         /// <param name="effect">Effect options.</param>
-        public void SetBreathingEffect(Breathing effect)
+        public void SetBreathing(Breathing effect)
         {
             Set(NativeWrapper.CreateKeyboardEffect(effect));
         }
@@ -154,7 +152,7 @@ namespace Corale.Colore.Core
         /// Sets the color of all keys on the keyboard.
         /// </summary>
         /// <param name="color">Color to set.</param>
-        public void SetAllKeysColor(Color color)
+        public void SetAll(Color color)
         {
             _grid.Set(color);
             Set(NativeWrapper.CreateKeyboardEffect(_grid));
@@ -168,7 +166,7 @@ namespace Corale.Colore.Core
         /// <param name="second">Color to reach, before going back to <paramref name="first" />.</param>
         public void SetBreathingColors(Color first, Color second)
         {
-            SetBreathingEffect(new Breathing(first, second));
+            SetBreathing(new Breathing(first, second));
         }
 
         /// <summary>

--- a/Corale.Colore/Core/Keyboard.cs
+++ b/Corale.Colore/Core/Keyboard.cs
@@ -30,13 +30,15 @@
 
 namespace Corale.Colore.Core
 {
-    using Corale.Colore.Annotations;
-    using Corale.Colore.Razer.Keyboard;
-    using Corale.Colore.Razer.Keyboard.Effects;
-    using log4net;
     using System;
     using System.Collections.Generic;
 
+    using Corale.Colore.Annotations;
+    using Corale.Colore.Razer.Keyboard;
+    using Corale.Colore.Razer.Keyboard.Effects;
+
+    using log4net;
+  
     /// <summary>
     /// Class for interacting with a Chroma keyboard.
     /// </summary>
@@ -152,7 +154,7 @@ namespace Corale.Colore.Core
         /// Sets the color of all keys on the keyboard.
         /// </summary>
         /// <param name="color">Color to set.</param>
-        public void SetAll(Color color)
+        public override void SetAll(Color color)
         {
             _grid.Set(color);
             Set(NativeWrapper.CreateKeyboardEffect(_grid));

--- a/Corale.Colore/Core/Keyboard.cs
+++ b/Corale.Colore/Core/Keyboard.cs
@@ -43,7 +43,7 @@ namespace Corale.Colore.Core
     /// Class for interacting with a Chroma keyboard.
     /// </summary>
     [PublicAPI]
-    public sealed class Keyboard : Device, IKeyboard
+    public sealed partial class Keyboard : Device, IKeyboard
     {
         /// <summary>
         /// Logger instance for this class.
@@ -107,7 +107,7 @@ namespace Corale.Colore.Core
 
             set
             {
-                SetKeyColor(key, value);
+                SetKey(key, value);
             }
         }
 
@@ -147,7 +147,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">Effect options.</param>
         public void SetBreathing(Breathing effect)
         {
-            Set(NativeWrapper.CreateKeyboardEffect(effect));
+            SetGuid(NativeWrapper.CreateKeyboardEffect(effect));
         }
 
         /// <summary>
@@ -157,7 +157,7 @@ namespace Corale.Colore.Core
         public override void SetAll(Color color)
         {
             _grid.Set(color);
-            Set(NativeWrapper.CreateKeyboardEffect(_grid));
+            SetGuid(NativeWrapper.CreateKeyboardEffect(_grid));
         }
 
         /// <summary>
@@ -210,14 +210,14 @@ namespace Corale.Colore.Core
         public void SetCustom(Custom effect)
         {
             _grid = effect;
-            Set(NativeWrapper.CreateKeyboardEffect(_grid));
+            SetGuid(NativeWrapper.CreateKeyboardEffect(_grid));
         }
 
         /// <summary>
         /// Sets a wave effect on the keyboard in the specified direction.
         /// </summary>
         /// <param name="direction">Direction of the wave.</param>
-        public void SetWaveWithDirection(Direction direction)
+        public void SetWave(Direction direction)
         {
             SetWave(new Wave(direction));
         }
@@ -229,7 +229,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">Effect options.</param>
         public void SetEffect(Effect effect)
         {
-            Set(NativeWrapper.CreateKeyboardEffect(effect));
+            SetGuid(NativeWrapper.CreateKeyboardEffect(effect));
         }
 
         /// <summary>
@@ -246,7 +246,7 @@ namespace Corale.Colore.Core
                 _grid.Clear();
 
             _grid[(int)row, (int)column] = color;
-            Set(NativeWrapper.CreateKeyboardEffect(_grid));
+            SetGuid(NativeWrapper.CreateKeyboardEffect(_grid));
         }
 
         /// <summary>
@@ -255,13 +255,13 @@ namespace Corale.Colore.Core
         /// <param name="key">Key to modify.</param>
         /// <param name="color">Color to set.</param>
         /// <param name="clear">If true, the keyboard will first be cleared before setting the key.</param>
-        public void SetKeyColor(Key key, Color color, bool clear = false)
+        public void SetKey(Key key, Color color, bool clear = false)
         {
             if (clear)
                 _grid.Clear();
 
             _grid[key] = color;
-            Set(NativeWrapper.CreateKeyboardEffect(_grid));
+            SetGuid(NativeWrapper.CreateKeyboardEffect(_grid));
         }
 
         /// <summary>
@@ -270,11 +270,11 @@ namespace Corale.Colore.Core
         /// <param name="color">The <see cref="Color" /> to apply.</param>
         /// <param name="key">First key to change.</param>
         /// <param name="keys">Additional keys that should also have the color applied.</param>
-        public void SetKeyGroupColor(Color color, Key key, params Key[] keys)
+        public void SetKeyGroup(Color color, Key key, params Key[] keys)
         {
-            SetKeyColor(key, color);
+            SetKey(key, color);
             foreach (var additional in keys)
-                SetKeyColor(additional, color);
+                SetKey(additional, color);
         }
 
         /// <summary>
@@ -286,13 +286,13 @@ namespace Corale.Colore.Core
         /// If <c>true</c>, the keyboard keys will be cleared before
         /// applying the new colors.
         /// </param>
-        public void SetKeyGroupColor(IEnumerable<Key> keys, Color color, bool clear = false)
+        public void SetKeyGroup(IEnumerable<Key> keys, Color color, bool clear = false)
         {
             if (clear)
                 Clear();
 
             foreach (var key in keys)
-                SetKeyColor(key, color);
+                SetKey(key, color);
         }
 
         /// <summary>
@@ -301,7 +301,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">Effect options.</param>
         public void SetReactive(Reactive effect)
         {
-            Set(NativeWrapper.CreateKeyboardEffect(effect));
+            SetGuid(NativeWrapper.CreateKeyboardEffect(effect));
         }
 
         /// <summary>
@@ -310,7 +310,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">Effect options.</param>
         public void SetStatic(Static effect)
         {
-            Set(NativeWrapper.CreateKeyboardEffect(effect));
+            SetGuid(NativeWrapper.CreateKeyboardEffect(effect));
         }
 
         /// <summary>
@@ -319,7 +319,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">Effect options.</param>
         public void SetWave(Wave effect)
         {
-            Set(NativeWrapper.CreateKeyboardEffect(effect));
+            SetGuid(NativeWrapper.CreateKeyboardEffect(effect));
         }
     }
 }

--- a/Corale.Colore/Core/Keyboard.cs
+++ b/Corale.Colore/Core/Keyboard.cs
@@ -107,7 +107,7 @@ namespace Corale.Colore.Core
 
             set
             {
-                Set(key, value);
+                SetKeyColor(key, value);
             }
         }
 
@@ -127,7 +127,7 @@ namespace Corale.Colore.Core
 
             set
             {
-                Set(row, column, value);
+                SetPosition(row, column, value);
             }
         }
 
@@ -145,7 +145,7 @@ namespace Corale.Colore.Core
         /// Sets a breathing effect on the keyboard.
         /// </summary>
         /// <param name="effect">Effect options.</param>
-        public void Set(Breathing effect)
+        public void SetBreathingEffect(Breathing effect)
         {
             Set(NativeWrapper.CreateKeyboardEffect(effect));
         }
@@ -154,7 +154,7 @@ namespace Corale.Colore.Core
         /// Sets the color of all keys on the keyboard.
         /// </summary>
         /// <param name="color">Color to set.</param>
-        public override void Set(Color color)
+        public void SetAllKeysColor(Color color)
         {
             _grid.Set(color);
             Set(NativeWrapper.CreateKeyboardEffect(_grid));
@@ -166,9 +166,9 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="first">Color to start from.</param>
         /// <param name="second">Color to reach, before going back to <paramref name="first" />.</param>
-        public void Set(Color first, Color second)
+        public void SetBreathingColors(Color first, Color second)
         {
-            Set(new Breathing(first, second));
+            SetBreathingEffect(new Breathing(first, second));
         }
 
         /// <summary>
@@ -177,9 +177,9 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="color">Color to emit on key press.</param>
         /// <param name="duration">How long to illuminate the key after being pressed.</param>
-        public void Set(Color color, Duration duration)
+        public void SetReactive(Color color, Duration duration)
         {
-            Set(new Reactive(color, duration));
+            SetReactive(new Reactive(color, duration));
         }
 
         /// <summary>
@@ -194,9 +194,9 @@ namespace Corale.Colore.Core
         /// This will overwrite the internal <see cref="Custom" />
         /// struct in the <see cref="Keyboard" /> class.
         /// </remarks>
-        public void Set(Color[][] colors)
+        public void SetCustomGrid(Color[][] colors)
         {
-            Set(new Custom(colors));
+            SetCustom(new Custom(colors));
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace Corale.Colore.Core
         /// This will overwrite the current internal <see cref="Custom" />
         /// struct in the <see cref="Keyboard" /> class.
         /// </remarks>
-        public void Set(Custom effect)
+        public void SetCustom(Custom effect)
         {
             _grid = effect;
             Set(NativeWrapper.CreateKeyboardEffect(_grid));
@@ -217,9 +217,9 @@ namespace Corale.Colore.Core
         /// Sets a wave effect on the keyboard in the specified direction.
         /// </summary>
         /// <param name="direction">Direction of the wave.</param>
-        public void Set(Direction direction)
+        public void SetWaveWithDirection(Direction direction)
         {
-            Set(new Wave(direction));
+            SetWave(new Wave(direction));
         }
 
         /// <summary>
@@ -227,7 +227,7 @@ namespace Corale.Colore.Core
         /// Currently, this only works for the <see cref="Effect.None" /> and <see cref="Effect.SpectrumCycling" /> effects.
         /// </summary>
         /// <param name="effect">Effect options.</param>
-        public void Set(Effect effect)
+        public void SetEffect(Effect effect)
         {
             Set(NativeWrapper.CreateKeyboardEffect(effect));
         }
@@ -240,7 +240,7 @@ namespace Corale.Colore.Core
         /// <param name="color">Color to set.</param>
         /// <param name="clear">Whether or not to clear the existing colors before setting this one.</param>
         /// <exception cref="ArgumentException">Thrown if the row or column parameters are outside the valid ranges.</exception>
-        public void Set(Size row, Size column, Color color, bool clear = false)
+        public void SetPosition(Size row, Size column, Color color, bool clear = false)
         {
             if (clear)
                 _grid.Clear();
@@ -255,7 +255,7 @@ namespace Corale.Colore.Core
         /// <param name="key">Key to modify.</param>
         /// <param name="color">Color to set.</param>
         /// <param name="clear">If true, the keyboard will first be cleared before setting the key.</param>
-        public void Set(Key key, Color color, bool clear = false)
+        public void SetKeyColor(Key key, Color color, bool clear = false)
         {
             if (clear)
                 _grid.Clear();
@@ -270,11 +270,11 @@ namespace Corale.Colore.Core
         /// <param name="color">The <see cref="Color" /> to apply.</param>
         /// <param name="key">First key to change.</param>
         /// <param name="keys">Additional keys that should also have the color applied.</param>
-        public void Set(Color color, Key key, params Key[] keys)
+        public void SetKeyGroupColor(Color color, Key key, params Key[] keys)
         {
-            Set(key, color);
+            SetKeyColor(key, color);
             foreach (var additional in keys)
-                Set(additional, color);
+                SetKeyColor(additional, color);
         }
 
         /// <summary>
@@ -286,20 +286,20 @@ namespace Corale.Colore.Core
         /// If <c>true</c>, the keyboard keys will be cleared before
         /// applying the new colors.
         /// </param>
-        public void Set(IEnumerable<Key> keys, Color color, bool clear = false)
+        public void SetKeyGroupColor(IEnumerable<Key> keys, Color color, bool clear = false)
         {
             if (clear)
                 Clear();
 
             foreach (var key in keys)
-                Set(key, color);
+                SetKeyColor(key, color);
         }
 
         /// <summary>
         /// Sets a reactive effect on the keyboard.
         /// </summary>
         /// <param name="effect">Effect options.</param>
-        public void Set(Reactive effect)
+        public void SetReactive(Reactive effect)
         {
             Set(NativeWrapper.CreateKeyboardEffect(effect));
         }
@@ -308,7 +308,7 @@ namespace Corale.Colore.Core
         /// Sets a static color on the keyboard.
         /// </summary>
         /// <param name="effect">Effect options.</param>
-        public void Set(Static effect)
+        public void SetStatic(Static effect)
         {
             Set(NativeWrapper.CreateKeyboardEffect(effect));
         }
@@ -317,7 +317,7 @@ namespace Corale.Colore.Core
         /// Sets a wave effect on the keyboard.
         /// </summary>
         /// <param name="effect">Effect options.</param>
-        public void Set(Wave effect)
+        public void SetWave(Wave effect)
         {
             Set(NativeWrapper.CreateKeyboardEffect(effect));
         }

--- a/Corale.Colore/Core/Keypad.cs
+++ b/Corale.Colore/Core/Keypad.cs
@@ -105,7 +105,7 @@ namespace Corale.Colore.Core
         /// <param name="color">Color to set.</param>
         public override void SetAll(Color color)
         {
-            Set(NativeWrapper.CreateKeypadEffect(new Static(color)));
+            SetGuid(NativeWrapper.CreateKeypadEffect(new Static(color)));
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">Effect options.</param>
         public void Set(Effect effect)
         {
-            Set(NativeWrapper.CreateKeypadEffect(effect));
+            SetGuid(NativeWrapper.CreateKeypadEffect(effect));
         }
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">An instance of the <see cref="Breathing" /> struct.</param>
         public void Set(Breathing effect)
         {
-            Set(NativeWrapper.CreateKeypadEffect(effect));
+            SetGuid(NativeWrapper.CreateKeypadEffect(effect));
         }
 
         /// <summary>
@@ -133,7 +133,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">An instance of the <see cref="Custom" /> struct.</param>
         public void Set(Custom effect)
         {
-            Set(NativeWrapper.CreateKeypadEffect(effect));
+            SetGuid(NativeWrapper.CreateKeypadEffect(effect));
         }
 
         /// <summary>
@@ -142,7 +142,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">An instance of the <see cref="Reactive" /> struct.</param>
         public void Set(Reactive effect)
         {
-            Set(NativeWrapper.CreateKeypadEffect(effect));
+            SetGuid(NativeWrapper.CreateKeypadEffect(effect));
         }
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">An instance of the <see cref="Static" /> struct.</param>
         public void Set(Static effect)
         {
-            Set(NativeWrapper.CreateKeypadEffect(effect));
+            SetGuid(NativeWrapper.CreateKeypadEffect(effect));
         }
 
         /// <summary>
@@ -160,7 +160,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">An instance of the <see cref="Wave" /> struct.</param>
         public void Set(Wave effect)
         {
-            Set(NativeWrapper.CreateKeypadEffect(effect));
+            SetGuid(NativeWrapper.CreateKeypadEffect(effect));
         }
     }
 }

--- a/Corale.Colore/Core/Keypad.cs
+++ b/Corale.Colore/Core/Keypad.cs
@@ -103,7 +103,7 @@ namespace Corale.Colore.Core
         /// Sets the color of all components on this device.
         /// </summary>
         /// <param name="color">Color to set.</param>
-        public override void Set(Color color)
+        public override void SetAll(Color color)
         {
             Set(NativeWrapper.CreateKeypadEffect(new Static(color)));
         }

--- a/Corale.Colore/Core/Mouse.cs
+++ b/Corale.Colore/Core/Mouse.cs
@@ -151,7 +151,7 @@ namespace Corale.Colore.Core
         /// Sets the color of all LEDs on the mouse.
         /// </summary>
         /// <param name="color">Color to set.</param>
-        public override void Set(Color color)
+        public override void SetAll(Color color)
         {
             Set(NativeWrapper.CreateMouseEffect(new Static(Led.All, color)));
         }

--- a/Corale.Colore/Core/Mouse.cs
+++ b/Corale.Colore/Core/Mouse.cs
@@ -80,7 +80,7 @@ namespace Corale.Colore.Core
         /// <param name="color">Color to set.</param>
         public void Set(Led led, Color color)
         {
-            Set(NativeWrapper.CreateMouseEffect(new Static(led, color)));
+            SetGuid(NativeWrapper.CreateMouseEffect(new Static(led, color)));
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">Effect options.</param>
         public void Set(Effect effect)
         {
-            Set(NativeWrapper.CreateMouseEffect(effect));
+            SetGuid(NativeWrapper.CreateMouseEffect(effect));
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">An instance of the <see cref="Breathing" /> effect.</param>
         public void Set(Breathing effect)
         {
-            Set(NativeWrapper.CreateMouseEffect(effect));
+            SetGuid(NativeWrapper.CreateMouseEffect(effect));
         }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">An instance of the <see cref="Static" /> effect.</param>
         public void Set(Static effect)
         {
-            Set(NativeWrapper.CreateMouseEffect(effect));
+            SetGuid(NativeWrapper.CreateMouseEffect(effect));
         }
 
         /// <summary>
@@ -117,7 +117,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">An instance of the <see cref="Blinking" /> effect.</param>
         public void Set(Blinking effect)
         {
-            Set(NativeWrapper.CreateMouseEffect(effect));
+            SetGuid(NativeWrapper.CreateMouseEffect(effect));
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">Effect options struct.</param>
         public void Set(Reactive effect)
         {
-            Set(NativeWrapper.CreateMouseEffect(effect));
+            SetGuid(NativeWrapper.CreateMouseEffect(effect));
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">Effect options struct.</param>
         public void Set(SpectrumCycling effect)
         {
-            Set(NativeWrapper.CreateMouseEffect(effect));
+            SetGuid(NativeWrapper.CreateMouseEffect(effect));
         }
 
         /// <summary>
@@ -144,7 +144,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">Effect options struct.</param>
         public void Set(Wave effect)
         {
-            Set(NativeWrapper.CreateMouseEffect(effect));
+            SetGuid(NativeWrapper.CreateMouseEffect(effect));
         }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace Corale.Colore.Core
         /// <param name="color">Color to set.</param>
         public override void SetAll(Color color)
         {
-            Set(NativeWrapper.CreateMouseEffect(new Static(Led.All, color)));
+            SetGuid(NativeWrapper.CreateMouseEffect(new Static(Led.All, color)));
         }
     }
 }

--- a/Corale.Colore/Core/Mouse.cs
+++ b/Corale.Colore/Core/Mouse.cs
@@ -40,7 +40,7 @@ namespace Corale.Colore.Core
     /// Class for interacting with a Chroma mouse.
     /// </summary>
     [PublicAPI]
-    public sealed class Mouse : Device, IMouse
+    public sealed partial class Mouse : Device, IMouse
     {
         /// <summary>
         /// Logger instance for this class.
@@ -78,7 +78,7 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="led">Which LED to modify.</param>
         /// <param name="color">Color to set.</param>
-        public void Set(Led led, Color color)
+        public void SetLed(Led led, Color color)
         {
             SetGuid(NativeWrapper.CreateMouseEffect(new Static(led, color)));
         }
@@ -88,7 +88,7 @@ namespace Corale.Colore.Core
         /// Currently, this only works for the <see cref="Effect.None" /> effect.
         /// </summary>
         /// <param name="effect">Effect options.</param>
-        public void Set(Effect effect)
+        public void SetEffect(Effect effect)
         {
             SetGuid(NativeWrapper.CreateMouseEffect(effect));
         }
@@ -97,7 +97,7 @@ namespace Corale.Colore.Core
         /// Sets a breathing effect on the mouse.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Breathing" /> effect.</param>
-        public void Set(Breathing effect)
+        public void SetBreathing(Breathing effect)
         {
             SetGuid(NativeWrapper.CreateMouseEffect(effect));
         }
@@ -106,7 +106,7 @@ namespace Corale.Colore.Core
         /// Sets a static color on the mouse.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Static" /> effect.</param>
-        public void Set(Static effect)
+        public void SetStatic(Static effect)
         {
             SetGuid(NativeWrapper.CreateMouseEffect(effect));
         }
@@ -115,7 +115,7 @@ namespace Corale.Colore.Core
         /// Starts a blinking effect on the specified LED.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Blinking" /> effect.</param>
-        public void Set(Blinking effect)
+        public void SetBlinking(Blinking effect)
         {
             SetGuid(NativeWrapper.CreateMouseEffect(effect));
         }
@@ -124,7 +124,7 @@ namespace Corale.Colore.Core
         /// Sets a reactive effect on the mouse.
         /// </summary>
         /// <param name="effect">Effect options struct.</param>
-        public void Set(Reactive effect)
+        public void SetReactive(Reactive effect)
         {
             SetGuid(NativeWrapper.CreateMouseEffect(effect));
         }
@@ -133,7 +133,7 @@ namespace Corale.Colore.Core
         /// Sets a spectrum cycling effect on the mouse.
         /// </summary>
         /// <param name="effect">Effect options struct.</param>
-        public void Set(SpectrumCycling effect)
+        public void SetSpectrumCycling(SpectrumCycling effect)
         {
             SetGuid(NativeWrapper.CreateMouseEffect(effect));
         }
@@ -142,7 +142,7 @@ namespace Corale.Colore.Core
         /// Sets a wave effect on the mouse.
         /// </summary>
         /// <param name="effect">Effect options struct.</param>
-        public void Set(Wave effect)
+        public void SetWave(Wave effect)
         {
             SetGuid(NativeWrapper.CreateMouseEffect(effect));
         }

--- a/Corale.Colore/Core/Mousepad.cs
+++ b/Corale.Colore/Core/Mousepad.cs
@@ -37,7 +37,7 @@ namespace Corale.Colore.Core
     /// <summary>
     /// Class for interacting with a Chroma mouse pad.
     /// </summary>
-    public sealed class Mousepad : Device, IMousepad
+    public sealed partial class Mousepad : Device, IMousepad
     {
         /// <summary>
         /// Logger instance for this class.
@@ -83,7 +83,7 @@ namespace Corale.Colore.Core
         /// Currently, this only works for the <see cref="Effect.None" /> effect.
         /// </summary>
         /// <param name="effect">Effect options.</param>
-        public void Set(Effect effect)
+        public void SetEffect(Effect effect)
         {
             Set(NativeWrapper.CreateMousepadEffect(effect));
         }
@@ -92,7 +92,7 @@ namespace Corale.Colore.Core
         /// Sets a breathing effect on the mouse pad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Breathing" /> struct.</param>
-        public void Set(Breathing effect)
+        public void SetBreathing(Breathing effect)
         {
             Set(NativeWrapper.CreateMousepadEffect(effect));
         }
@@ -101,7 +101,7 @@ namespace Corale.Colore.Core
         /// Sets a static color effect on the mouse pad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Static" /> struct.</param>
-        public void Set(Static effect)
+        public void SetStatic(Static effect)
         {
             Set(NativeWrapper.CreateMousepadEffect(effect));
         }
@@ -110,7 +110,7 @@ namespace Corale.Colore.Core
         /// Sets a wave effect on the mouse pad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Wave" /> struct.</param>
-        public void Set(Wave effect)
+        public void SetWave(Wave effect)
         {
             Set(NativeWrapper.CreateMousepadEffect(effect));
         }
@@ -119,7 +119,7 @@ namespace Corale.Colore.Core
         /// Sets a custom effect on the mouse pad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Custom" /> struct.</param>
-        public void Set(Custom effect)
+        public void SetCustom(Custom effect)
         {
             Set(NativeWrapper.CreateMousepadEffect(effect));
         }

--- a/Corale.Colore/Core/Mousepad.cs
+++ b/Corale.Colore/Core/Mousepad.cs
@@ -73,7 +73,7 @@ namespace Corale.Colore.Core
         /// Sets the color of all components on this device.
         /// </summary>
         /// <param name="color">Color to set.</param>
-        public override void Set(Color color)
+        public override void SetAll(Color color)
         {
             Set(NativeWrapper.CreateMousepadEffect(new Static(color)));
         }

--- a/Corale.Colore/Core/Mousepad.cs
+++ b/Corale.Colore/Core/Mousepad.cs
@@ -75,7 +75,7 @@ namespace Corale.Colore.Core
         /// <param name="color">Color to set.</param>
         public override void SetAll(Color color)
         {
-            Set(NativeWrapper.CreateMousepadEffect(new Static(color)));
+            SetGuid(NativeWrapper.CreateMousepadEffect(new Static(color)));
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">Effect options.</param>
         public void SetEffect(Effect effect)
         {
-            Set(NativeWrapper.CreateMousepadEffect(effect));
+            SetGuid(NativeWrapper.CreateMousepadEffect(effect));
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">An instance of the <see cref="Breathing" /> struct.</param>
         public void SetBreathing(Breathing effect)
         {
-            Set(NativeWrapper.CreateMousepadEffect(effect));
+            SetGuid(NativeWrapper.CreateMousepadEffect(effect));
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">An instance of the <see cref="Static" /> struct.</param>
         public void SetStatic(Static effect)
         {
-            Set(NativeWrapper.CreateMousepadEffect(effect));
+            SetGuid(NativeWrapper.CreateMousepadEffect(effect));
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">An instance of the <see cref="Wave" /> struct.</param>
         public void SetWave(Wave effect)
         {
-            Set(NativeWrapper.CreateMousepadEffect(effect));
+            SetGuid(NativeWrapper.CreateMousepadEffect(effect));
         }
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace Corale.Colore.Core
         /// <param name="effect">An instance of the <see cref="Custom" /> struct.</param>
         public void SetCustom(Custom effect)
         {
-            Set(NativeWrapper.CreateMousepadEffect(effect));
+            SetGuid(NativeWrapper.CreateMousepadEffect(effect));
         }
     }
 }

--- a/Corale.Colore/Core/NativeWrapper.cs
+++ b/Corale.Colore/Core/NativeWrapper.cs
@@ -442,7 +442,7 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
-        /// Set effect.
+        /// SetGuid effect.
         /// </summary>
         /// <param name="guid">Effect ID to set.</param>
         internal static void SetEffect(Guid guid)

--- a/Corale.Colore/Core/SimpleHeadset.cs
+++ b/Corale.Colore/Core/SimpleHeadset.cs
@@ -1,5 +1,5 @@
 ﻿// ---------------------------------------------------------------------------------------
-// <copyright file="Headset.cs" company="Corale">
+// <copyright file="SimpleHeadset.cs" company="Corale">
 //     Copyright © 2015 by Adam Hellberg and Brandon Scott.
 //
 //     Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -30,9 +30,8 @@
 
 namespace Corale.Colore.Core
 {
+    using System;
     using Corale.Colore.Razer.Headset.Effects;
-
-    using log4net;
 
     /// <summary>
     /// Class for interacting with Chroma Headsets.
@@ -40,53 +39,15 @@ namespace Corale.Colore.Core
     public sealed partial class Headset : Device, IHeadset
     {
         /// <summary>
-        /// Loggers instance for this class.
-        /// </summary>
-        private static readonly ILog Log = LogManager.GetLogger(typeof(Headset));
-
-        /// <summary>
-        /// Holds the application-wide instance of the <see cref="IHeadset" /> interface.
-        /// </summary>
-        private static IHeadset _instance;
-
-        /// <summary>
-        /// Prevents a default instance of the <see cref="Headset" /> class from being created.
-        /// </summary>
-        private Headset()
-        {
-            Log.Info("Headset is initializing");
-            Chroma.Initialize();
-        }
-
-        /// <summary>
-        /// Gets the application-wide instance of the <see cref="IHeadset" /> interface.
-        /// </summary>
-        public static IHeadset Instance
-        {
-            get
-            {
-                return _instance ?? (_instance = new Headset());
-            }
-        }
-
-        /// <summary>
-        /// Sets the color of all components on this device.
-        /// </summary>
-        /// <param name="color">Color to set.</param>
-        public override void SetAll(Color color)
-        {
-            SetStatic(new Static(color));
-        }
-
-        /// <summary>
         /// Sets an effect on the headset that doesn't
         /// take any parameters, currently only valid
         /// for the <see cref="Effect.SpectrumCycling" /> effect.
         /// </summary>
         /// <param name="effect">The type of effect to set.</param>
-        public void SetEffect(Effect effect)
+        [Obsolete("Set is deprecated, please use SetEffect.", false)]
+        public void Set(Effect effect)
         {
-            SetGuid(NativeWrapper.CreateHeadsetEffect(effect));
+            SetEffect(effect);
         }
 
         /// <summary>
@@ -96,9 +57,10 @@ namespace Corale.Colore.Core
         /// An instance of the <see cref="Static" /> struct
         /// describing the effect.
         /// </param>
-        public void SetStatic(Static effect)
+        [Obsolete("Set is deprecated, please use SetStatic.", false)]
+        public void Set(Static effect)
         {
-            SetGuid(NativeWrapper.CreateHeadsetEffect(effect));
+            SetStatic(effect);
         }
 
         /// <summary>
@@ -108,9 +70,10 @@ namespace Corale.Colore.Core
         /// An instance of the <see cref="Breathing" /> struct
         /// describing the effect.
         /// </param>
-        public void SetBreathing(Breathing effect)
+        [Obsolete("Set is deprecated, please use SetBreathing.", false)]
+        public void Set(Breathing effect)
         {
-            SetGuid(NativeWrapper.CreateHeadsetEffect(effect));
+            SetBreathing(effect);
         }
     }
 }

--- a/Corale.Colore/Core/SimpleKeyboard.cs
+++ b/Corale.Colore/Core/SimpleKeyboard.cs
@@ -1,0 +1,224 @@
+﻿// ---------------------------------------------------------------------------------------
+// <copyright file="SimpleKeyboard.cs" company="Corale">
+//     Copyright © 2015 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     Disclaimer: Corale and/or Colore is in no way affiliated with Razer and/or any
+//     of its employees and/or licensors. Corale, Adam Hellberg, and/or Brandon Scott
+//     do not take responsibility for any harm caused, direct or indirect, to any
+//     Razer peripherals via the use of Colore.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+// ---------------------------------------------------------------------------------------
+
+namespace Corale.Colore.Core
+{
+    using System;
+    using System.Collections.Generic;
+
+    using Corale.Colore.Razer.Keyboard;
+    using Corale.Colore.Razer.Keyboard.Effects;
+
+    /// <summary>
+    /// Class for interacting with a Chroma keyboard.
+    /// </summary>
+    public sealed partial class Keyboard
+    {
+        /// <summary>
+        /// Sets a breathing effect on the keyboard.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        [Obsolete("Set is deprecated, please use SetBreathing.", false)]
+        public void Set(Breathing effect)
+        {
+            SetBreathing(effect);
+        }
+
+        /// <summary>
+        /// Sets the color of all keys on the keyboard.
+        /// </summary>
+        /// <param name="color">Color to set.</param>
+        [Obsolete("Set is deprecated, please use SetAll.", false)]
+        public void Set(Color color)
+        {
+            SetAll(color);
+        }
+
+        /// <summary>
+        /// Sets a breathing effect on the keyboard, fading between the
+        /// two specified colors.
+        /// </summary>
+        /// <param name="first">Color to start from.</param>
+        /// <param name="second">Color to reach, before going back to <paramref name="first" />.</param>
+        [Obsolete("Set is deprecated, please use SetBreathing.", false)]
+        public void Set(Color first, Color second)
+        {
+            SetBreathing(new Breathing(first, second));
+        }
+
+        /// <summary>
+        /// Sets a reactive effect on the keyboard with the specified
+        /// color and duration.
+        /// </summary>
+        /// <param name="color">Color to emit on key press.</param>
+        /// <param name="duration">How long to illuminate the key after being pressed.</param>
+        [Obsolete("Set is deprecated, please use SetReactive.", false)]
+        public void Set(Color color, Duration duration)
+        {
+            SetReactive(color, duration);
+        }
+
+        /// <summary>
+        /// Sets a custom grid effect on the keyboard using
+        /// a two dimensional array of color values.
+        /// </summary>
+        /// <param name="colors">The grid of colors to use.</param>
+        /// <remarks>
+        /// The passed in arrays cannot have more than <see cref="Constants.MaxRows" /> rows and
+        /// not more than <see cref="Constants.MaxColumns" /> columns in any row.
+        /// <para />
+        /// This will overwrite the internal <see cref="Custom" />
+        /// struct in the <see cref="Keyboard" /> class.
+        /// </remarks>
+        [Obsolete("Set is deprecated, please use SetCustom.", false)]
+        public void Set(Color[][] colors)
+        {
+            SetCustomGrid(colors);
+        }
+
+        /// <summary>
+        /// Sets a custom grid effect on the keyboard.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        /// <remarks>
+        /// This will overwrite the current internal <see cref="Custom" />
+        /// struct in the <see cref="Keyboard" /> class.
+        /// </remarks>
+        [Obsolete("Set is deprecated, please use SetCustom.", false)]
+        public void Set(Custom effect)
+        {
+           SetCustom(effect);
+        }
+
+        /// <summary>
+        /// Sets a wave effect on the keyboard in the specified direction.
+        /// </summary>
+        /// <param name="direction">Direction of the wave.</param>
+        [Obsolete("Set is deprecated, please use SetWave.", false)]
+        public void Set(Direction direction)
+        {
+            SetWave(direction);
+        }
+
+        /// <summary>
+        /// Sets an effect without any parameters.
+        /// Currently, this only works for the <see cref="Effect.None" /> and <see cref="Effect.SpectrumCycling" /> effects.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        [Obsolete("Set is deprecated, please use SetEffect.", false)]
+        public void Set(Effect effect)
+        {
+            SetEffect(effect);
+        }
+
+        /// <summary>
+        /// Sets the color on a specific row and column on the keyboard grid.
+        /// </summary>
+        /// <param name="row">Row to set, between 0 and <see cref="Constants.MaxRows" /> (exclusive upper-bound).</param>
+        /// <param name="column">Column to set, between 0 and <see cref="Constants.MaxColumns" /> (exclusive upper-bound).</param>
+        /// <param name="color">Color to set.</param>
+        /// <param name="clear">Whether or not to clear the existing colors before setting this one.</param>
+        /// <exception cref="ArgumentException">Thrown if the row or column parameters are outside the valid ranges.</exception>
+        [Obsolete("Set is deprecated, please use SetPosition.", false)]
+        public void Set(Size row, Size column, Color color, bool clear = false)
+        {
+            SetPosition(row, column, color, clear);
+        }
+
+        /// <summary>
+        /// Sets the color of a specific key on the keyboard.
+        /// </summary>
+        /// <param name="key">Key to modify.</param>
+        /// <param name="color">Color to set.</param>
+        /// <param name="clear">If true, the keyboard will first be cleared before setting the key.</param>
+        [Obsolete("Set is deprecated, please use SetKey.", false)]
+        public void Set(Key key, Color color, bool clear = false)
+        {
+            SetKey(key, color, clear);
+        }
+
+        /// <summary>
+        /// Sets the specified color on a set of keys.
+        /// </summary>
+        /// <param name="color">The <see cref="Color" /> to apply.</param>
+        /// <param name="key">First key to change.</param>
+        /// <param name="keys">Additional keys that should also have the color applied.</param>
+        [Obsolete("Set is deprecated, please use SetKeyGroup.", false)]
+        public void Set(Color color, Key key, params Key[] keys)
+        {
+            SetKeyGroup(color, key, keys);
+        }
+
+        /// <summary>
+        /// Sets a color on a collection of keys.
+        /// </summary>
+        /// <param name="keys">The keys which should have their color changed.</param>
+        /// <param name="color">The <see cref="Color" /> to apply.</param>
+        /// <param name="clear">
+        /// If <c>true</c>, the keyboard keys will be cleared before
+        /// applying the new colors.
+        /// </param>
+        [Obsolete("Set is deprecated, please use SetKeyGroup.", false)]
+        public void Set(IEnumerable<Key> keys, Color color, bool clear = false)
+        {
+           SetKeyGroup(keys, color, clear);
+        }
+
+        /// <summary>
+        /// Sets a reactive effect on the keyboard.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        [Obsolete("Set is deprecated, please use SetReactive.", false)]
+        public void Set(Reactive effect)
+        {
+            SetReactive(effect);
+        }
+
+        /// <summary>
+        /// Sets a static color on the keyboard.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        [Obsolete("Set is deprecated, please use SetStatic.", false)]
+        public void Set(Static effect)
+        {
+            SetStatic(effect);
+        }
+
+        /// <summary>
+        /// Sets a wave effect on the keyboard.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        [Obsolete("Set is deprecated, please use SetWave.", false)]
+        public void Set(Wave effect)
+        {
+            SetWave(effect);
+        }
+    }
+}

--- a/Corale.Colore/Core/SimpleKeypad.cs
+++ b/Corale.Colore/Core/SimpleKeypad.cs
@@ -1,5 +1,5 @@
 ﻿// ---------------------------------------------------------------------------------------
-// <copyright file="Keypad.cs" company="Corale">
+// <copyright file="SimpleKeypad.cs" company="Corale">
 //     Copyright © 2015 by Adam Hellberg and Brandon Scott.
 //
 //     Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -30,10 +30,8 @@
 
 namespace Corale.Colore.Core
 {
-    using Corale.Colore.Razer.Keypad;
+    using System;
     using Corale.Colore.Razer.Keypad.Effects;
-
-    using log4net;
 
     /// <summary>
     /// Class for interacting with a Chroma keypad.
@@ -41,126 +39,64 @@ namespace Corale.Colore.Core
     public sealed partial class Keypad : Device, IKeypad
     {
         /// <summary>
-        /// Logger instance for this class.
-        /// </summary>
-        private static readonly ILog Log = LogManager.GetLogger(typeof(Keypad));
-
-        /// <summary>
-        /// Singleton instance of this class.
-        /// </summary>
-        private static IKeypad _instance;
-
-        /// <summary>
-        /// Internal instance of a <see cref="Custom" /> struct used for
-        /// the indexer.
-        /// </summary>
-        private Custom _custom;
-
-        /// <summary>
-        /// Prevents a default instance of the <see cref="Keypad" /> class from being created.
-        /// </summary>
-        private Keypad()
-        {
-            Log.Debug("Keypad is initializing");
-            Chroma.Initialize();
-
-            _custom = new Custom(Color.Black);
-        }
-
-        /// <summary>
-        /// Gets the application-wide instance of the <see cref="IKeypad" /> interface.
-        /// </summary>
-        public static IKeypad Instance
-        {
-            get
-            {
-                return _instance ?? (_instance = new Keypad());
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a color at the specified position in the keypad's
-        /// grid layout.
-        /// </summary>
-        /// <param name="row">The row to access (between <c>0</c> and <see cref="Constants.MaxRows" />).</param>
-        /// <param name="column">The column to access (between <c>0</c> and <see cref="Constants.MaxColumns" />).</param>
-        /// <returns>The <see cref="Color" /> at the specified position.</returns>
-        public Color this[int row, int column]
-        {
-            get
-            {
-                return _custom[row, column];
-            }
-
-            set
-            {
-                _custom[row, column] = value;
-                SetCustom(_custom);
-            }
-        }
-
-        /// <summary>
-        /// Sets the color of all components on this device.
-        /// </summary>
-        /// <param name="color">Color to set.</param>
-        public override void SetAll(Color color)
-        {
-            SetGuid(NativeWrapper.CreateKeypadEffect(new Static(color)));
-        }
-
-        /// <summary>
         /// Sets an effect without any parameters.
         /// Currently, this only works for the <see cref="Effect.None" /> effect.
         /// </summary>
         /// <param name="effect">Effect options.</param>
-        public void SetEffect(Effect effect)
+        [Obsolete("Set is deprecated, please use SetEffect.", false)]
+        public void Set(Effect effect)
         {
-            SetGuid(NativeWrapper.CreateKeypadEffect(effect));
+            SetEffect(effect);
         }
 
         /// <summary>
         /// Sets a <see cref="Breathing" /> effect on the keypad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Breathing" /> struct.</param>
-        public void SetBreathing(Breathing effect)
+        [Obsolete("Set is deprecated, please use SetBreathing.", false)]
+        public void Set(Breathing effect)
         {
-            SetGuid(NativeWrapper.CreateKeypadEffect(effect));
+            SetBreathing(effect);
         }
 
         /// <summary>
         /// Sets a <see cref="Custom" /> effect on the keypad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Custom" /> struct.</param>
-        public void SetCustom(Custom effect)
+        [Obsolete("Set is deprecated, please use SetCustom.", false)]
+        public void Set(Custom effect)
         {
-            SetGuid(NativeWrapper.CreateKeypadEffect(effect));
+            SetCustom(effect);
         }
 
         /// <summary>
         /// Sets a <see cref="Reactive" /> effect on the keypad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Reactive" /> struct.</param>
-        public void SetReactive(Reactive effect)
+        [Obsolete("Set is deprecated, please use SetReactive.", false)]
+        public void Set(Reactive effect)
         {
-            SetGuid(NativeWrapper.CreateKeypadEffect(effect));
+           SetReactive(effect);
         }
 
         /// <summary>
         /// Sets a <see cref="Static" /> effect on the keypad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Static" /> struct.</param>
-        public void SetStatic(Static effect)
+        [Obsolete("Set is deprecated, please use SetStatic.", false)]
+        public void Set(Static effect)
         {
-            SetGuid(NativeWrapper.CreateKeypadEffect(effect));
+            SetStatic(effect);
         }
 
         /// <summary>
         /// Sets a <see cref="Wave" /> effect on the keypad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Wave" /> struct.</param>
-        public void SetWave(Wave effect)
+        [Obsolete("Set is deprecated, please use SetWave.", false)]
+        public void Set(Wave effect)
         {
-            SetGuid(NativeWrapper.CreateKeypadEffect(effect));
+            SetWave(effect);
         }
     }
 }

--- a/Corale.Colore/Core/SimpleMouse.cs
+++ b/Corale.Colore/Core/SimpleMouse.cs
@@ -1,5 +1,5 @@
 ﻿// ---------------------------------------------------------------------------------------
-// <copyright file="IMouse.cs" company="Corale">
+// <copyright file="SimpleMouse.cs" company="Corale">
 //     Copyright © 2015 by Adam Hellberg and Brandon Scott.
 //
 //     Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -30,67 +30,96 @@
 
 namespace Corale.Colore.Core
 {
-    using Corale.Colore.Annotations;
+    using System;
+
     using Corale.Colore.Razer.Mouse;
     using Corale.Colore.Razer.Mouse.Effects;
 
     /// <summary>
-    /// Interface for mouse functionality.
+    /// Class for interacting with a Chroma mouse.
     /// </summary>
-    public interface IMouse : IDevice
+    public sealed partial class Mouse
     {
         /// <summary>
         /// Sets the color of a specific LED on the mouse.
         /// </summary>
         /// <param name="led">Which LED to modify.</param>
         /// <param name="color">Color to set.</param>
-        [PublicAPI]
-        void SetLed(Led led, Color color);
+        [Obsolete("Set is deprecated, please use SetLed.", false)]
+        public void Set(Led led, Color color)
+        {
+            SetLed(led, color);
+        }
 
         /// <summary>
         /// Sets an effect without any parameters.
         /// Currently, this only works for the <see cref="Effect.None" /> effect.
         /// </summary>
         /// <param name="effect">Effect options.</param>
-        [PublicAPI]
-        void SetEffect(Effect effect);
+        [Obsolete("Set is deprecated, please use SetEffect.", false)]
+        public void Set(Effect effect)
+        {
+            SetEffect(effect);
+        }
 
         /// <summary>
         /// Sets a breathing effect on the mouse.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Breathing" /> effect.</param>
-        [PublicAPI]
-        void SetBreathing(Breathing effect);
+        [Obsolete("Set is deprecated, please use SetBreathing.", false)]
+        public void Set(Breathing effect)
+        {
+            SetBreathing(effect);
+        }
 
         /// <summary>
         /// Sets a static color on the mouse.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Static" /> effect.</param>
-        [PublicAPI]
-        void SetStatic(Static effect);
+        [Obsolete("Set is deprecated, please use SetStatic.", false)]
+        public void Set(Static effect)
+        {
+            SetStatic(effect);
+        }
 
         /// <summary>
         /// Starts a blinking effect on the specified LED.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Blinking" /> effect.</param>
-        void SetBlinking(Blinking effect);
+        [Obsolete("Set is deprecated, please use SetBlinking.", false)]
+        public void Set(Blinking effect)
+        {
+            SetBlinking(effect);
+        }
 
         /// <summary>
         /// Sets a reactive effect on the mouse.
         /// </summary>
         /// <param name="effect">Effect options struct.</param>
-        void SetReactive(Reactive effect);
+        [Obsolete("Set is deprecated, please use SetReactive.", false)]
+        public void Set(Reactive effect)
+        {
+            SetReactive(effect);
+        }
 
         /// <summary>
         /// Sets a spectrum cycling effect on the mouse.
         /// </summary>
         /// <param name="effect">Effect options struct.</param>
-        void SetSpectrumCycling(SpectrumCycling effect);
+        [Obsolete("Set is deprecated, please use SetSpectrumCycling.", false)]
+        public void Set(SpectrumCycling effect)
+        {
+            SetSpectrumCycling(effect);
+        }
 
         /// <summary>
         /// Sets a wave effect on the mouse.
         /// </summary>
         /// <param name="effect">Effect options struct.</param>
-        void SetWave(Wave effect);
+        [Obsolete("Set is deprecated, please use SetWave.", false)]
+        public void Set(Wave effect)
+        {
+            SetWave(effect);
+        }
     }
 }

--- a/Corale.Colore/Core/SimpleMousepad.cs
+++ b/Corale.Colore/Core/SimpleMousepad.cs
@@ -1,0 +1,92 @@
+﻿// ---------------------------------------------------------------------------------------
+// <copyright file="SimpleMousepad.cs" company="Corale">
+//     Copyright © 2015 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     Disclaimer: Corale and/or Colore is in no way affiliated with Razer and/or any
+//     of its employees and/or licensors. Corale, Adam Hellberg, and/or Brandon Scott
+//     do not take responsibility for any harm caused, direct or indirect, to any
+//     Razer peripherals via the use of Colore.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+// ---------------------------------------------------------------------------------------
+
+namespace Corale.Colore.Core
+{
+    using System;
+    using Corale.Colore.Razer.Mousepad.Effects;
+
+    /// <summary>
+    /// Class for interacting with a Chroma mouse pad.
+    /// </summary>
+    public sealed partial class Mousepad
+    {
+        /// <summary>
+        /// Sets an effect without any parameters.
+        /// Currently, this only works for the <see cref="Effect.None" /> effect.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        [Obsolete("Set is deprecated, please use SetEffect.", false)]
+        public void Set(Effect effect)
+        {
+            SetGuid(NativeWrapper.CreateMousepadEffect(effect));
+        }
+
+        /// <summary>
+        /// Sets a breathing effect on the mouse pad.
+        /// </summary>
+        /// <param name="effect">An instance of the <see cref="Breathing" /> struct.</param>
+        [Obsolete("Set is deprecated, please use SetBreathing.", false)]
+        public void Set(Breathing effect)
+        {
+            SetGuid(NativeWrapper.CreateMousepadEffect(effect));
+        }
+
+        /// <summary>
+        /// Sets a static color effect on the mouse pad.
+        /// </summary>
+        /// <param name="effect">An instance of the <see cref="Static" /> struct.</param>
+        [Obsolete("Set is deprecated, please use SetStatic.", false)]
+        public void Set(Static effect)
+        {
+            SetGuid(NativeWrapper.CreateMousepadEffect(effect));
+        }
+
+        /// <summary>
+        /// Sets a wave effect on the mouse pad.
+        /// </summary>
+        /// <param name="effect">An instance of the <see cref="Wave" /> struct.</param>
+        [Obsolete("Set is deprecated, please use SetWave.", false)]
+        public void Set(Wave effect)
+        {
+            SetGuid(NativeWrapper.CreateMousepadEffect(effect));
+        }
+
+        /// <summary>
+        /// Sets a custom effect on the mouse pad.
+        /// </summary>
+        /// <param name="effect">An instance of the <see cref="Custom" /> struct.</param>
+        [Obsolete("Set is deprecated, please use SetCustom.", false)]
+        public void Set(Custom effect)
+        {
+            SetGuid(NativeWrapper.CreateMousepadEffect(effect));
+        }
+    }
+}

--- a/Corale.Colore/Razer/NativeMethods.cs
+++ b/Corale.Colore/Razer/NativeMethods.cs
@@ -299,7 +299,7 @@ namespace Corale.Colore.Razer
         /// Depends on which LED.
         /// </param>
         /// <param name="param">Pointer to a parameter type specified by <paramref name="effect" />.</param>
-        /// <param name="effectId">Set to valid effect ID if successful. Pass <see cref="IntPtr.Zero" /> if not required.</param>
+        /// <param name="effectId">SetGuid to valid effect ID if successful. Pass <see cref="IntPtr.Zero" /> if not required.</param>
         /// <returns><see cref="Result" /> value indicating success.</returns>
         /// <remarks>
         /// The <paramref name="param" /> parameter should point to the relevant struct for the passed in effect,
@@ -334,7 +334,7 @@ namespace Corale.Colore.Razer
         /// </summary>
         /// <param name="effect">Standard effect type.</param>
         /// <param name="param">Pointer to a parameter type specified by <paramref name="effect" />.</param>
-        /// <param name="effectId">Set to valid effect ID if successful. Pass <see cref="IntPtr.Zero" /> if not required.</param>
+        /// <param name="effectId">SetGuid to valid effect ID if successful. Pass <see cref="IntPtr.Zero" /> if not required.</param>
         /// <returns><see cref="Result" /> value indicating success.</returns>
         [UnmanagedFunctionPointer(FunctionConvention, SetLastError = true)]
         internal delegate Result CreateHeadsetEffectDelegate(
@@ -377,7 +377,7 @@ namespace Corale.Colore.Razer
         internal delegate Result DeleteEffectDelegate([In] Guid effectId);
 
         /// <summary>
-        /// Set effect.
+        /// SetGuid effect.
         /// </summary>
         /// <param name="effectId">ID of the effect that needs to be set.</param>
         /// <returns><see cref="Result" /> value indicating success.</returns>
@@ -573,7 +573,7 @@ namespace Corale.Colore.Razer
         /// Depends on which LED.
         /// </param>
         /// <param name="param">Pointer to a parameter type specified by <paramref name="effect" />.</param>
-        /// <param name="effectId">Set to valid effect ID if successful. Pass <see cref="IntPtr.Zero" /> if not required.</param>
+        /// <param name="effectId">SetGuid to valid effect ID if successful. Pass <see cref="IntPtr.Zero" /> if not required.</param>
         /// <returns><see cref="Result" /> value indicating success.</returns>
         /// <remarks>
         /// The <paramref name="param" /> parameter should point to the relevant struct for the passed in effect,
@@ -609,7 +609,7 @@ namespace Corale.Colore.Razer
         /// </summary>
         /// <param name="effect">Standard effect type.</param>
         /// <param name="param">Pointer to a parameter type specified by <paramref name="effect" />.</param>
-        /// <param name="effectId">Set to valid effect ID if successful. Pass <see cref="IntPtr.Zero" /> if not required.</param>
+        /// <param name="effectId">SetGuid to valid effect ID if successful. Pass <see cref="IntPtr.Zero" /> if not required.</param>
         /// <returns><see cref="Result" /> value indicating success.</returns>
         [DllImport(DllName, CallingConvention = FunctionConvention, EntryPoint = "CreateHeadsetEffect", SetLastError = true)]
         internal static extern Result CreateHeadsetEffect(
@@ -652,7 +652,7 @@ namespace Corale.Colore.Razer
         internal static extern Result DeleteEffect([In] Guid effectId);
 
         /// <summary>
-        /// Set effect.
+        /// SetGuid effect.
         /// </summary>
         /// <param name="effectId">ID of the effect that needs to be set.</param>
         /// <returns><see cref="Result" /> value indicating success.</returns>


### PR DESCRIPTION
Refactoring 'Set' methods into more descriptive (more verbose) methods.  The number of 'Set' methods had increased after a few iterations of Razer Chroma SDK.

Links to issue #38 .