### PR TITLE
Improve branch detection in version script

### DIFF
--- a/set_version.ps1
+++ b/set_version.ps1
@@ -39,6 +39,7 @@ elseif ($branch -eq 'develop')
 }
 elseif ($branch -match "^v\d+\.\d+\.\d+$")
 {
+    $isTag = $True
     $friendlyVersion = $branch.substring(1)
     $buildNumber = "${friendlyVersion}.${buildCounter}"
 }


### PR DESCRIPTION
The version script currently has a bug that doesn't mark version tags as tags, this change will fix that to build packages with correction version strings.

Fixes #53.