### PR TITLE
Update devices to use Custom effects where available

### DIFF
--- a/Corale.Colore/Core/Keypad.cs
+++ b/Corale.Colore/Core/Keypad.cs
@@ -64,7 +64,7 @@ namespace Corale.Colore.Core
             Log.Debug("Keypad is initializing");
             Chroma.Initialize();
 
-            _custom = new Custom(Color.Black);
+            _custom = Custom.Create();
         }
 
         /// <summary>
@@ -105,7 +105,8 @@ namespace Corale.Colore.Core
         /// <param name="color">Color to set.</param>
         public override void SetAll(Color color)
         {
-            SetGuid(NativeWrapper.CreateKeypadEffect(new Static(color)));
+            _custom.Set(color);
+            SetCustom(_custom);
         }
 
         /// <summary>

--- a/Corale.Colore/Core/Mouse.cs
+++ b/Corale.Colore/Core/Mouse.cs
@@ -53,12 +53,18 @@ namespace Corale.Colore.Core
         private static IMouse _instance;
 
         /// <summary>
+        /// Internal instance of a <see cref="Custom" /> struct.
+        /// </summary>
+        private Custom _custom;
+
+        /// <summary>
         /// Prevents a default instance of the <see cref="Mouse" /> class from being created.
         /// </summary>
         private Mouse()
         {
             Log.Info("Mouse is initializing");
             Chroma.Initialize();
+            _custom = Custom.Create();
         }
 
         /// <summary>
@@ -80,7 +86,8 @@ namespace Corale.Colore.Core
         /// <param name="color">Color to set.</param>
         public void SetLed(Led led, Color color)
         {
-            SetGuid(NativeWrapper.CreateMouseEffect(new Static(led, color)));
+            _custom[led] = color;
+            SetCustom(_custom);
         }
 
         /// <summary>
@@ -153,7 +160,8 @@ namespace Corale.Colore.Core
         /// <param name="color">Color to set.</param>
         public override void SetAll(Color color)
         {
-            SetGuid(NativeWrapper.CreateMouseEffect(new Static(Led.All, color)));
+            _custom.Set(color);
+            SetCustom(_custom);
         }
 
         /// <summary>

--- a/Corale.Colore/Core/Mousepad.cs
+++ b/Corale.Colore/Core/Mousepad.cs
@@ -50,12 +50,18 @@ namespace Corale.Colore.Core
         private static IMousepad _instance;
 
         /// <summary>
+        /// Internal <see cref="Custom" /> struct used for effects.
+        /// </summary>
+        private Custom _custom;
+
+        /// <summary>
         /// Prevents a default instance of the <see cref="Mousepad" /> class from being created.
         /// </summary>
         private Mousepad()
         {
             Log.Debug("Mousepad is initializing.");
             Chroma.Initialize();
+            _custom = Custom.Create();
         }
 
         /// <summary>
@@ -75,7 +81,8 @@ namespace Corale.Colore.Core
         /// <param name="color">Color to set.</param>
         public override void SetAll(Color color)
         {
-            SetGuid(NativeWrapper.CreateMousepadEffect(new Static(color)));
+            _custom.Set(color);
+            SetCustom(_custom);
         }
 
         /// <summary>

--- a/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
@@ -196,12 +196,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         /// </summary>
         public void Clear()
         {
-            for (var row = 0; row < (int)Constants.MaxRows; row++)
-            {
-                var rowArr = _rows[row];
-                for (var col = 0; col < (int)Constants.MaxColumns; col++)
-                    rowArr[col] = Color.Black;
-            }
+            Set(Color.Black);
         }
 
         /// <summary>

--- a/Corale.Colore/Razer/Keypad/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keypad/Effects/Custom.cs
@@ -146,6 +146,7 @@ namespace Corale.Colore.Razer.Keypad.Effects
         /// </summary>
         /// <returns>An instance of <see cref="Custom" />
         /// filled with the color black.</returns>
+        [PublicAPI]
         public static Custom Create()
         {
             return new Custom(Color.Black);
@@ -163,17 +164,19 @@ namespace Corale.Colore.Razer.Keypad.Effects
             return _rows == null ? 0 : _rows.GetHashCode();
         }
 
+        public void Set(Color color)
+        {
+            for (var row = 0; row < Constants.MaxRows; row++)
+                _rows[row].Set(color);
+        }
+
         /// <summary>
         /// Clears the colors from the grid, setting them to <see cref="Color.Black" />.
         /// </summary>
+        [PublicAPI]
         public void Clear()
         {
-            for (var row = 0; row < Constants.MaxRows; row++)
-            {
-                var rowArr = _rows[row];
-                for (var col = 0; col < Constants.MaxColumns; col++)
-                    rowArr[col] = Color.Black;
-            }
+            Set(Color.Black);
         }
 
         /// <summary>
@@ -260,7 +263,7 @@ namespace Corale.Colore.Razer.Keypad.Effects
             /// Color definitions for the columns of this row.
             /// </summary>
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.MaxColumns)]
-            internal readonly uint[] Columns;
+            private readonly uint[] _columns;
 
             /// <summary>
             /// Initializes a new instance of the <see cref="Row" /> struct.
@@ -275,10 +278,10 @@ namespace Corale.Colore.Razer.Keypad.Effects
                         "colors");
                 }
 
-                Columns = new uint[Constants.MaxColumns];
+                _columns = new uint[Constants.MaxColumns];
 
                 for (var col = 0; col < Constants.MaxColumns; col++)
-                    Columns[col] = colors[col];
+                    _columns[col] = colors[col];
             }
 
             /// <summary>
@@ -288,10 +291,10 @@ namespace Corale.Colore.Razer.Keypad.Effects
             /// <param name="color">The <see cref="Color" /> to set each column to.</param>
             internal Row(Color color)
             {
-                Columns = new uint[Constants.MaxColumns];
+                _columns = new uint[Constants.MaxColumns];
 
                 for (var col = 0; col < Constants.MaxColumns; col++)
-                    Columns[col] = color;
+                    _columns[col] = color;
             }
 
             /// <summary>
@@ -311,7 +314,7 @@ namespace Corale.Colore.Razer.Keypad.Effects
                             "Attempted to access a column that does not exist.");
                     }
 
-                    return Columns[column];
+                    return _columns[column];
                 }
 
                 set
@@ -324,7 +327,7 @@ namespace Corale.Colore.Razer.Keypad.Effects
                             "Attempted to access a column that does not exist.");
                     }
 
-                    Columns[column] = value;
+                    _columns[column] = value;
                 }
             }
 
@@ -335,7 +338,7 @@ namespace Corale.Colore.Razer.Keypad.Effects
             /// <returns>An array of unsigned integeres representing the colors of the row.</returns>
             public static implicit operator uint[](Row row)
             {
-                return row.Columns;
+                return row._columns;
             }
 
             /// <summary>
@@ -347,7 +350,17 @@ namespace Corale.Colore.Razer.Keypad.Effects
             /// <filterpriority>2</filterpriority>
             public override int GetHashCode()
             {
-                return Columns == null ? 0 : Columns.GetHashCode();
+                return _columns == null ? 0 : _columns.GetHashCode();
+            }
+
+            /// <summary>
+            /// Sets the entire row to a specific <see cref="Color" />.
+            /// </summary>
+            /// <param name="color">The <see cref="Color" /> to apply.</param>
+            public void Set(Color color)
+            {
+                for (var column = 0; column < Constants.MaxColumns; column++)
+                    _columns[column] = color;
             }
         }
     }

--- a/Corale.Colore/Razer/Keypad/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keypad/Effects/Custom.cs
@@ -164,6 +164,10 @@ namespace Corale.Colore.Razer.Keypad.Effects
             return _rows == null ? 0 : _rows.GetHashCode();
         }
 
+        /// <summary>
+        /// Sets all LED indices to the specified <see cref="Color" />.
+        /// </summary>
+        /// <param name="color">The <see cref="Color" /> to set.</param>
         public void Set(Color color)
         {
             for (var row = 0; row < Constants.MaxRows; row++)

--- a/Corale.Colore/Razer/Mouse/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Mouse/Effects/Custom.cs
@@ -101,7 +101,7 @@ namespace Corale.Colore.Razer.Mouse.Effects
                     throw new ArgumentOutOfRangeException(
                         "led",
                         led,
-                        "Attemped to access an LED that was out of range.");
+                        "Attempted to access an LED that was out of range.");
                 }
 
                 return Colors[led];

--- a/Corale.Colore/Razer/Mouse/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Mouse/Effects/Custom.cs
@@ -209,7 +209,7 @@ namespace Corale.Colore.Razer.Mouse.Effects
         /// <filterpriority>2</filterpriority>
         public override int GetHashCode()
         {
-            return (Colors != null ? Colors.GetHashCode() : 0);
+            return Colors != null ? Colors.GetHashCode() : 0;
         }
 
         /// <summary>

--- a/Corale.Colore/Razer/Mouse/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Mouse/Effects/Custom.cs
@@ -101,7 +101,7 @@ namespace Corale.Colore.Razer.Mouse.Effects
                     throw new ArgumentOutOfRangeException(
                         "led",
                         led,
-                        "Attemped to access an LED index that was out of range.");
+                        "Attemped to access an LED that was out of range.");
                 }
 
                 return Colors[led];
@@ -114,7 +114,7 @@ namespace Corale.Colore.Razer.Mouse.Effects
                     throw new ArgumentOutOfRangeException(
                         "led",
                         led,
-                        "Attempted to access an LED index that was out of range.");
+                        "Attempted to access an LED that was out of range.");
                 }
 
                 Colors[led] = value;

--- a/Corale.Colore/Razer/Mouse/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Mouse/Effects/Custom.cs
@@ -28,22 +28,28 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------
 
+#pragma warning disable 618
+
 namespace Corale.Colore.Razer.Mouse.Effects
 {
+    using System;
+    using System.Collections.Generic;
     using System.Runtime.InteropServices;
 
+    using Corale.Colore.Annotations;
     using Corale.Colore.Core;
 
     /// <summary>
     /// Custom effect for mouse LEDs.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public struct Custom
+    public struct Custom : IEquatable<Custom>, IEquatable<IList<Color>>
     {
         /// <summary>
         /// Colors for each LED.
         /// </summary>
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.MaxLeds)]
+        [Obsolete("Accessing the Color array directly has been deprecated, please use the indexer instead.")]
         public readonly Color[] Colors;
 
         /// <summary>
@@ -57,6 +63,214 @@ namespace Corale.Colore.Razer.Mouse.Effects
 
             for (var i = 0; i < Colors.Length; i++)
                 Colors[i] = color;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Custom" /> struct.
+        /// </summary>
+        /// <param name="colors">The colors to use.</param>
+        /// <exception cref="ArgumentException">Thrown if the colors list supplied is of an incorrect size.</exception>
+        public Custom(IList<Color> colors)
+        {
+            if (colors.Count != Constants.MaxLeds)
+            {
+                throw new ArgumentException(
+                    "Colors list has incorrect number of rows, should be " + Constants.MaxLeds + ", received "
+                    + colors.Count,
+                    "colors");
+            }
+
+            Colors = new Color[Constants.MaxLeds];
+
+            for (var index = 0; index < Constants.MaxLeds; index++)
+                Colors[index] = colors[index];
+        }
+
+        /// <summary>
+        /// Gets or sets LEDs in the custom array.
+        /// </summary>
+        /// <param name="led">Index of the LED to access.</param>
+        /// <returns>The <see cref="Color" /> at the specified position.</returns>
+        [PublicAPI]
+        public Color this[int led]
+        {
+            get
+            {
+                if (led < 0 || led >= Constants.MaxLeds)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        "led",
+                        led,
+                        "Attemped to access an LED index that was out of range.");
+                }
+
+                return Colors[led];
+            }
+
+            set
+            {
+                if (led < 0 || led > Constants.MaxLeds)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        "led",
+                        led,
+                        "Attempted to access an LED index that was out of range.");
+                }
+
+                Colors[led] = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets LEDs in the custom array.
+        /// </summary>
+        /// <param name="led">The LED to access.</param>
+        /// <returns>The <see cref="Color" /> of the specified LED.</returns>
+        [PublicAPI]
+        public Color this[Led led]
+        {
+            get
+            {
+                if (led == Led.All)
+                    throw new ArgumentException("Led.All cannot be accessed through indexer.", "led");
+
+                return this[(int)led];
+            }
+
+            set
+            {
+                if (led == Led.All)
+                    throw new ArgumentException("Led.All cannot be accessed through indexer.", "led");
+
+                this[(int)led] = value;
+            }
+        }
+
+        /// <summary>
+        /// Compares an instance of <see cref="Custom" /> with
+        /// another object for equality.
+        /// </summary>
+        /// <param name="left">The left operand, an instance of <see cref="Custom" />.</param>
+        /// <param name="right">The right operand, any type of object.</param>
+        /// <returns><c>true</c> if the two objects are equal, otherwise <c>false</c>.</returns>
+        public static bool operator ==(Custom left, object right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Compares an instance of <see cref="Custom" /> with
+        /// another object for inequality.
+        /// </summary>
+        /// <param name="left">The left operand, an instance of <see cref="Custom" />.</param>
+        /// <param name="right">The right operand, any type of object.</param>
+        /// <returns><c>true</c> if the two objects are not equal, otherwise <c>false</c>.</returns>
+        public static bool operator !=(Custom left, object right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <summary>
+        /// Create a new empty <see cref="Custom" /> struct.
+        /// </summary>
+        /// <returns>An instance of <see cref="Custom" /> filled with the color black.</returns>
+        [PublicAPI]
+        public static Custom Create()
+        {
+            return new Custom(Color.Black);
+        }
+
+        /// <summary>
+        /// Sets all the LED indices to the specified <see cref="Color" />.
+        /// </summary>
+        /// <param name="color">The <see cref="Color" /> to set the LEDs to.</param>
+        [PublicAPI]
+        public void Set(Color color)
+        {
+            for (var index = 0; index < Constants.MaxLeds; index++)
+                Colors[index] = color;
+        }
+
+        /// <summary>
+        /// Clears the colors in this <see cref="Custom" /> struct (sets to <see cref="Color.Black" />).
+        /// </summary>
+        [PublicAPI]
+        public void Clear()
+        {
+            Set(Color.Black);
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A 32-bit signed integer that is the hash code for this instance.
+        /// </returns>
+        /// <filterpriority>2</filterpriority>
+        public override int GetHashCode()
+        {
+            return (Colors != null ? Colors.GetHashCode() : 0);
+        }
+
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">Another object to compare to.</param>
+        /// <returns>
+        /// <c>true</c> if <paramref name="obj"/> and this instance are the same type
+        /// and represent the same value; otherwise, <c>false</c>.
+        /// </returns>
+        /// <filterpriority>2</filterpriority>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(obj, null))
+                return false;
+
+            if (obj is Custom)
+                return Equals((Custom)obj);
+
+            var list = obj as IList<Color>;
+            return list != null && Equals(list);
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// <c>true</c> if the current object is equal to the <paramref name="other"/> parameter; otherwise, <c>false</c>.
+        /// </returns>
+        public bool Equals(Custom other)
+        {
+            for (var index = 0; index < Constants.MaxLeds; index++)
+            {
+                if (this[index] != other[index])
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to an
+        /// instance of <see cref="IList{Color}" />.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// <c>true</c> if the current object is equal to the <paramref name="other"/> parameter; otherwise, <c>false</c>.
+        /// </returns>
+        public bool Equals(IList<Color> other)
+        {
+            if (other == null || other.Count != Constants.MaxLeds)
+                return false;
+
+            for (var index = 0; index < Constants.MaxLeds; index++)
+            {
+                if (this[index] != other[index])
+                    return false;
+            }
+
+            return true;
         }
     }
 }

--- a/Corale.Colore/Razer/Mousepad/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Mousepad/Effects/Custom.cs
@@ -163,7 +163,7 @@ namespace Corale.Colore.Razer.Mousepad.Effects
         /// <filterpriority>2</filterpriority>
         public override int GetHashCode()
         {
-            return (Colors != null ? Colors.GetHashCode() : 0);
+            return Colors != null ? Colors.GetHashCode() : 0;
         }
 
         /// <summary>

--- a/Corale.Colore/Razer/Mousepad/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Mousepad/Effects/Custom.cs
@@ -28,22 +28,28 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------
 
+#pragma warning disable 618
+
 namespace Corale.Colore.Razer.Mousepad.Effects
 {
+    using System;
+    using System.Collections.Generic;
     using System.Runtime.InteropServices;
 
+    using Corale.Colore.Annotations;
     using Corale.Colore.Core;
 
     /// <summary>
     /// Custom effect for mouse pad.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public struct Custom
+    public struct Custom : IEquatable<Custom>, IEquatable<IList<Color>>
     {
         /// <summary>
         /// Colors for the LEDs.
         /// </summary>
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.MaxLeds)]
+        [Obsolete("Accessing the Colors array directly has been deprecated, please use the indexer instead.")]
         public readonly Color[] Colors;
 
         /// <summary>
@@ -57,6 +63,188 @@ namespace Corale.Colore.Razer.Mousepad.Effects
 
             for (var i = 0; i < Colors.Length; i++)
                 Colors[i] = color;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Custom" /> struct.
+        /// </summary>
+        /// <param name="colors">The colors to use.</param>
+        /// <exception cref="ArgumentException">Thrown if the colors list supplied is of an incorrect size.</exception>
+        public Custom(IList<Color> colors)
+        {
+            if (colors.Count != Constants.MaxLeds)
+            {
+                throw new ArgumentException(
+                    "Invalid length of color list, expected " + Constants.MaxLeds + " but received " + colors.Count,
+                    "colors");
+            }
+
+            Colors = new Color[Constants.MaxLeds];
+
+            for (var i = 0; i < Colors.Length; i++)
+                Colors[i] = colors[i];
+        }
+
+        /// <summary>
+        /// Gets or sets LEDs in the custom array.
+        /// </summary>
+        /// <param name="led">Index of the LED to access.</param>
+        /// <returns>The <see cref="Color" /> at the specified position.</returns>
+        [PublicAPI]
+        public Color this[int led]
+        {
+            get
+            {
+                if (led < 0 || led >= Constants.MaxLeds)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        "led",
+                        led,
+                        "Attempted to access an LED that was out of range.");
+                }
+
+                return Colors[led];
+            }
+
+            set
+            {
+                if (led < 0 || led >= Constants.MaxLeds)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        "led",
+                        led,
+                        "Attempted to access an LED that was out of range.");
+                }
+
+                Colors[led] = value;
+            }
+        }
+
+        /// <summary>
+        /// Compares an instance of <see cref="Custom" /> with
+        /// another object for equality.
+        /// </summary>
+        /// <param name="left">The left operand, an instance of <see cref="Custom" />.</param>
+        /// <param name="right">The right operand, any type of object.</param>
+        /// <returns><c>true</c> if the two objects are equal, otherwise <c>false</c>.</returns>
+        public static bool operator ==(Custom left, object right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Compares an instance of <see cref="Custom" /> with
+        /// another object for inequality.
+        /// </summary>
+        /// <param name="left">The left operand, an instance of <see cref="Custom" />.</param>
+        /// <param name="right">The right operand, any type of object.</param>
+        /// <returns><c>true</c> if the two objects are not equal, otherwise <c>false</c>.</returns>
+        public static bool operator !=(Custom left, object right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <summary>
+        /// Create a new empty <see cref="Custom" /> struct.
+        /// </summary>
+        /// <returns>An instance of <see cref="Custom" /> filled with the color black.</returns>
+        [PublicAPI]
+        public static Custom Create()
+        {
+            return new Custom(Color.Black);
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>
+        /// A 32-bit signed integer that is the hash code for this instance.
+        /// </returns>
+        /// <filterpriority>2</filterpriority>
+        public override int GetHashCode()
+        {
+            return (Colors != null ? Colors.GetHashCode() : 0);
+        }
+
+        /// <summary>
+        /// Sets all the LED indices to the specified <see cref="Color" />.
+        /// </summary>
+        /// <param name="color">The <see cref="Color" /> to set the LEDs to.</param>
+        [PublicAPI]
+        public void Set(Color color)
+        {
+            for (var i = 0; i < Constants.MaxLeds; i++)
+                Colors[i] = color;
+        }
+
+        /// <summary>
+        /// Clears the colors in this <see cref="Custom" /> struct (sets to <see cref="Color.Black" />).
+        /// </summary>
+        [PublicAPI]
+        public void Clear()
+        {
+            Set(Color.Black);
+        }
+
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <param name="obj">Another object to compare to.</param>
+        /// <returns>
+        /// <c>true</c> if <paramref name="obj"/> and this instance are the same type
+        /// and represent the same value; otherwise, <c>false</c>.
+        /// </returns>
+        /// <filterpriority>2</filterpriority>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(obj, null))
+                return false;
+
+            if (obj is Custom)
+                return Equals((Custom)obj);
+
+            var list = obj as IList<Color>;
+            return list != null && Equals(list);
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// <c>true</c> if the current object is equal to the <paramref name="other"/> parameter; otherwise, <c>false</c>.
+        /// </returns>
+        public bool Equals(Custom other)
+        {
+            for (var i = 0; i < Constants.MaxLeds; i++)
+            {
+                if (this[i] != other[i])
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to an
+        /// instance of <see cref="IList{Color}" />.
+        /// </summary>
+        /// <param name="other">An object to compare with this object.</param>
+        /// <returns>
+        /// <c>true</c> if the current object is equal to the <paramref name="other"/> parameter; otherwise, <c>false</c>.
+        /// </returns>
+        public bool Equals(IList<Color> other)
+        {
+            if (other == null || other.Count != Constants.MaxLeds)
+                return false;
+
+            for (var i = 0; i < Constants.MaxLeds; i++)
+            {
+                if (this[i] != other[i])
+                    return false;
+            }
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
This PR updates all devices to make use of `Custom` effects rather than `Static` for updating basic colors.

Also updates the non-Keyboard `Custom` structs to have more functionality similar to Keyboard's.