### PR TITLE
Fix import attributes for Kernel32 functions

### DIFF
--- a/Corale.Colore/EnvironmentHelper.cs
+++ b/Corale.Colore/EnvironmentHelper.cs
@@ -62,5 +62,14 @@ namespace Corale.Colore
             bool result;
             return NativeMethods.IsWow64Process(NativeMethods.GetCurrentProcess(), out result) && result;
         }
+
+        /// <summary>
+        /// Determines whether this process is a 64-bit process.
+        /// </summary>
+        /// <returns><c>true</c> if this process is 64-bit, otherwise <c>false</c>.</returns>
+        internal static bool Is64BitProcess()
+        {
+            return IntPtr.Size == 8;
+        }
     }
 }

--- a/Corale.Colore/Native/Kernel32/NativeMethods.cs
+++ b/Corale.Colore/Native/Kernel32/NativeMethods.cs
@@ -43,16 +43,18 @@ namespace Corale.Colore.Native.Kernel32
         /// </summary>
         private const string DllName = "kernel32.dll";
 
-        [DllImport(DllName, CharSet = CharSet.Auto, EntryPoint = "GetProcAddress", SetLastError = true)]
+        [DllImport(DllName, CharSet = CharSet.Ansi, EntryPoint = "GetProcAddress", ExactSpelling = true,
+            SetLastError = true, BestFitMapping = false)]
         internal static extern IntPtr GetProcAddress(IntPtr module, string procName);
 
-        [DllImport(DllName, CharSet = CharSet.Auto, EntryPoint = "LoadLibrary", SetLastError = true)]
+        [DllImport(DllName, CharSet = CharSet.Ansi, EntryPoint = "LoadLibrary", SetLastError = true)]
         internal static extern IntPtr LoadLibrary([MarshalAs(UnmanagedType.LPStr)] string filename);
 
-        [DllImport(DllName, CharSet = CharSet.Auto, EntryPoint = "GetCurrentProcess", SetLastError = true)]
+        [DllImport(DllName, EntryPoint = "GetCurrentProcess", SetLastError = true)]
         internal static extern IntPtr GetCurrentProcess();
 
-        [DllImport(DllName, CharSet = CharSet.Auto, EntryPoint = "GetModuleHandle", SetLastError = true)]
+        [DllImport(DllName, CharSet = CharSet.Ansi, EntryPoint = "GetModuleHandle", SetLastError = true,
+            BestFitMapping = false)]
         internal static extern IntPtr GetModuleHandle(string moduleName);
 
         [DllImport(DllName, EntryPoint = "IsWow64Process", SetLastError = true,

--- a/Corale.Colore/Native/Kernel32/NativeMethods.cs
+++ b/Corale.Colore/Native/Kernel32/NativeMethods.cs
@@ -44,23 +44,26 @@ namespace Corale.Colore.Native.Kernel32
         private const string DllName = "kernel32.dll";
 
         [DllImport(DllName, CharSet = CharSet.Ansi, EntryPoint = "GetProcAddress", ExactSpelling = true,
-            SetLastError = true, ThrowOnUnmappableChar = true, BestFitMapping = false)]
-        internal static extern IntPtr GetProcAddress(IntPtr module, [MarshalAs(UnmanagedType.LPStr)] string procName);
+            SetLastError = true)]
+        internal static extern IntPtr GetProcAddress(IntPtr module, string procName);
 
-        [DllImport(DllName, CharSet = CharSet.Ansi, EntryPoint = "LoadLibrary", SetLastError = true,
-            ThrowOnUnmappableChar = true, BestFitMapping = false)]
+        [DllImport(DllName, CharSet = CharSet.Ansi, EntryPoint = "LoadLibrary", ExactSpelling = true,
+            SetLastError = true)]
         internal static extern IntPtr LoadLibrary([MarshalAs(UnmanagedType.LPStr)] string filename);
 
-        [DllImport(DllName, CharSet = CharSet.Ansi, EntryPoint = "GetCurrentProcess", SetLastError = true,
-            ThrowOnUnmappableChar = true, BestFitMapping = false)]
+        [DllImport(DllName, CharSet = CharSet.Ansi, EntryPoint = "GetCurrentProcess", ExactSpelling = true,
+            SetLastError = true)]
         internal static extern IntPtr GetCurrentProcess();
 
-        [DllImport(DllName, CharSet = CharSet.Ansi, EntryPoint = "GetModuleHandle", SetLastError = true,
-            ThrowOnUnmappableChar = true, BestFitMapping = false)]
+        [DllImport(DllName, CharSet = CharSet.Auto, EntryPoint = "GetModuleHandle", ExactSpelling = true,
+            SetLastError = true)]
         internal static extern IntPtr GetModuleHandle(string moduleName);
 
-        [DllImport(DllName, CharSet = CharSet.Ansi, EntryPoint = "GetModuleHandle", SetLastError = true,
-            ThrowOnUnmappableChar = true, BestFitMapping = false)]
-        internal static extern bool IsWow64Process(IntPtr hProcess, out bool wow64Process);
+        [DllImport(DllName, EntryPoint = "IsWow64Process", ExactSpelling = true, SetLastError = true,
+            CallingConvention = CallingConvention.Winapi)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool IsWow64Process(
+            [In] IntPtr hProcess,
+            [Out] [MarshalAs(UnmanagedType.Bool)] out bool wow64Process);
     }
 }

--- a/Corale.Colore/Native/Kernel32/NativeMethods.cs
+++ b/Corale.Colore/Native/Kernel32/NativeMethods.cs
@@ -43,23 +43,19 @@ namespace Corale.Colore.Native.Kernel32
         /// </summary>
         private const string DllName = "kernel32.dll";
 
-        [DllImport(DllName, CharSet = CharSet.Ansi, EntryPoint = "GetProcAddress", ExactSpelling = true,
-            SetLastError = true)]
+        [DllImport(DllName, CharSet = CharSet.Auto, EntryPoint = "GetProcAddress", SetLastError = true)]
         internal static extern IntPtr GetProcAddress(IntPtr module, string procName);
 
-        [DllImport(DllName, CharSet = CharSet.Ansi, EntryPoint = "LoadLibrary", ExactSpelling = true,
-            SetLastError = true)]
+        [DllImport(DllName, CharSet = CharSet.Auto, EntryPoint = "LoadLibrary", SetLastError = true)]
         internal static extern IntPtr LoadLibrary([MarshalAs(UnmanagedType.LPStr)] string filename);
 
-        [DllImport(DllName, CharSet = CharSet.Ansi, EntryPoint = "GetCurrentProcess", ExactSpelling = true,
-            SetLastError = true)]
+        [DllImport(DllName, CharSet = CharSet.Auto, EntryPoint = "GetCurrentProcess", SetLastError = true)]
         internal static extern IntPtr GetCurrentProcess();
 
-        [DllImport(DllName, CharSet = CharSet.Auto, EntryPoint = "GetModuleHandle", ExactSpelling = true,
-            SetLastError = true)]
+        [DllImport(DllName, CharSet = CharSet.Auto, EntryPoint = "GetModuleHandle", SetLastError = true)]
         internal static extern IntPtr GetModuleHandle(string moduleName);
 
-        [DllImport(DllName, EntryPoint = "IsWow64Process", ExactSpelling = true, SetLastError = true,
+        [DllImport(DllName, EntryPoint = "IsWow64Process", SetLastError = true,
             CallingConvention = CallingConvention.Winapi)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool IsWow64Process(

--- a/Corale.Colore/Razer/NativeMethods.cs
+++ b/Corale.Colore/Razer/NativeMethods.cs
@@ -160,7 +160,7 @@ namespace Corale.Colore.Razer
             Justification = "Can't get rid of this exception as we depend on architecture and library to work.")]
         static NativeMethods()
         {
-            if (EnvironmentHelper.Is64BitOperatingSystem())
+            if (EnvironmentHelper.Is64BitProcess() && EnvironmentHelper.Is64BitOperatingSystem())
             {
                 // We are running 64-bit!
                 ChromaSdkPointer = Native.Kernel32.NativeMethods.LoadLibrary("RzChromaSDK64.dll");

--- a/Corale.Colore/Razer/NativeMethods.cs
+++ b/Corale.Colore/Razer/NativeMethods.cs
@@ -174,7 +174,10 @@ namespace Corale.Colore.Razer
             }
 
             if (ChromaSdkPointer == IntPtr.Zero)
-                throw new ColoreException("Failed to dynamically load Chroma SDK library.");
+            {
+                throw new ColoreException(
+                    "Failed to dynamically load Chroma SDK library (Error " + Marshal.GetLastWin32Error() + ").");
+            }
 
             Init = GetDelegateFromLibrary<InitDelegate>(ChromaSdkPointer, "Init");
 


### PR DESCRIPTION
The DllImport attribute for IsWow64Process incorrectly states the
EntryPoint as "GetModuleHandle".

Also updated attributes for all Kernel32 functions to match that given by
PInvoke.net.