### PR TITLE
Add helper methods to non-keyboard classes

### DIFF
--- a/Corale.Colore/Core/Headset.cs
+++ b/Corale.Colore/Core/Headset.cs
@@ -102,6 +102,16 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Sets a new <see cref="Static" /> effect on
+        /// the headset using the specified <see cref="Color" />.
+        /// </summary>
+        /// <param name="color"><see cref="Color" /> of the effect.</param>
+        public void SetStatic(Color color)
+        {
+            SetStatic(new Static(color));
+        }
+
+        /// <summary>
         /// Sets a new breathing effect on the headset.
         /// </summary>
         /// <param name="effect">
@@ -111,6 +121,16 @@ namespace Corale.Colore.Core
         public void SetBreathing(Breathing effect)
         {
             SetGuid(NativeWrapper.CreateHeadsetEffect(effect));
+        }
+
+        /// <summary>
+        /// Sets a new <see cref="Breathing" /> effect on the headset
+        /// using the specified <see cref="Color" />.
+        /// </summary>
+        /// <param name="color"><see cref="Color"/> of the effect.</param>
+        public void SetBreathing(Color color)
+        {
+            SetBreathing(new Breathing(color));
         }
     }
 }

--- a/Corale.Colore/Core/IHeadset.cs
+++ b/Corale.Colore/Core/IHeadset.cs
@@ -30,6 +30,7 @@
 
 namespace Corale.Colore.Core
 {
+    using Corale.Colore.Annotations;
     using Corale.Colore.Razer.Headset.Effects;
 
     /// <summary>
@@ -43,6 +44,7 @@ namespace Corale.Colore.Core
         /// for the <see cref="Effect.SpectrumCycling" /> effect.
         /// </summary>
         /// <param name="effect">The type of effect to set.</param>
+        [PublicAPI]
         void SetEffect(Effect effect);
 
         /// <summary>
@@ -52,6 +54,7 @@ namespace Corale.Colore.Core
         /// An instance of the <see cref="Static" /> struct
         /// describing the effect.
         /// </param>
+        [PublicAPI]
         void SetStatic(Static effect);
 
         /// <summary>
@@ -61,6 +64,7 @@ namespace Corale.Colore.Core
         /// An instance of the <see cref="Breathing" /> struct
         /// describing the effect.
         /// </param>
+        [PublicAPI]
         void SetBreathing(Breathing effect);
     }
 }

--- a/Corale.Colore/Core/IHeadset.cs
+++ b/Corale.Colore/Core/IHeadset.cs
@@ -58,6 +58,14 @@ namespace Corale.Colore.Core
         void SetStatic(Static effect);
 
         /// <summary>
+        /// Sets a new <see cref="Static" /> effect on
+        /// the headset using the specified <see cref="Color" />.
+        /// </summary>
+        /// <param name="color"><see cref="Color" /> of the effect.</param>
+        [PublicAPI]
+        void SetStatic(Color color);
+
+        /// <summary>
         /// Sets a new breathing effect on the headset.
         /// </summary>
         /// <param name="effect">
@@ -66,5 +74,13 @@ namespace Corale.Colore.Core
         /// </param>
         [PublicAPI]
         void SetBreathing(Breathing effect);
+
+        /// <summary>
+        /// Sets a new <see cref="Breathing" /> effect on the headset
+        /// using the specified <see cref="Color" />.
+        /// </summary>
+        /// <param name="color"><see cref="Color"/> of the effect.</param>
+        [PublicAPI]
+        void SetBreathing(Color color);
     }
 }

--- a/Corale.Colore/Core/IKeypad.cs
+++ b/Corale.Colore/Core/IKeypad.cs
@@ -50,11 +50,36 @@ namespace Corale.Colore.Core
         Color this[int row, int column] { get; set; }
 
         /// <summary>
+        /// Returns whether a key has had a custom color set.
+        /// </summary>
+        /// <param name="row">The row to query.</param>
+        /// <param name="column">The column to query.</param>
+        /// <returns><c>true</c> if the position has a color set that is not black, otherwise <c>false</c>.</returns>
+        [PublicAPI]
+        bool IsSet(int row, int column);
+
+        /// <summary>
         /// Sets a <see cref="Breathing" /> effect on the keypad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Breathing" /> struct.</param>
         [PublicAPI]
         void SetBreathing(Breathing effect);
+
+        /// <summary>
+        /// Sets a <see cref="Breathing" /> effect on the keypad
+        /// using the specified <see cref="Color" />.
+        /// </summary>
+        /// <param name="first">The first color to breathe into.</param>
+        /// <param name="second">Second color to breathe into.</param>
+        [PublicAPI]
+        void SetBreathing(Color first, Color second);
+
+        /// <summary>
+        /// Sets an effect on the keypad to breathe
+        /// between randomly chosen colors.
+        /// </summary>
+        [PublicAPI]
+        void SetBreathing();
 
         /// <summary>
         /// Sets a <see cref="Custom" /> effect on the keypad.
@@ -71,6 +96,15 @@ namespace Corale.Colore.Core
         void SetReactive(Reactive effect);
 
         /// <summary>
+        /// Sets a <see cref="Reactive" /> effect on the keypad
+        /// with the specified parameters.
+        /// </summary>
+        /// <param name="duration">Duration of the effect.</param>
+        /// <param name="color">Color of the effect.</param>
+        [PublicAPI]
+        void SetReactive(Duration duration, Color color);
+
+        /// <summary>
         /// Sets a <see cref="Static" /> effect on the keypad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Static" /> struct.</param>
@@ -78,11 +112,25 @@ namespace Corale.Colore.Core
         void SetStatic(Static effect);
 
         /// <summary>
+        /// Sets a <see cref="Static" /> effect on the keypad.
+        /// </summary>
+        /// <param name="color">Color of the effect.</param>
+        [PublicAPI]
+        void SetStatic(Color color);
+
+        /// <summary>
         /// Sets a <see cref="Wave" /> effect on the keypad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Wave" /> struct.</param>
         [PublicAPI]
         void SetWave(Wave effect);
+
+        /// <summary>
+        /// Sets a <see cref="Wave" /> effect on the keypad.
+        /// </summary>
+        /// <param name="direction">Direction of the wave.</param>
+        [PublicAPI]
+        void SetWave(Direction direction);
 
         /// <summary>
         /// Sets an effect without any parameters.

--- a/Corale.Colore/Core/IMouse.cs
+++ b/Corale.Colore/Core/IMouse.cs
@@ -73,24 +73,28 @@ namespace Corale.Colore.Core
         /// Starts a blinking effect on the specified LED.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Blinking" /> effect.</param>
+        [PublicAPI]
         void SetBlinking(Blinking effect);
 
         /// <summary>
         /// Sets a reactive effect on the mouse.
         /// </summary>
         /// <param name="effect">Effect options struct.</param>
+        [PublicAPI]
         void SetReactive(Reactive effect);
 
         /// <summary>
         /// Sets a spectrum cycling effect on the mouse.
         /// </summary>
         /// <param name="effect">Effect options struct.</param>
+        [PublicAPI]
         void SetSpectrumCycling(SpectrumCycling effect);
 
         /// <summary>
         /// Sets a wave effect on the mouse.
         /// </summary>
         /// <param name="effect">Effect options struct.</param>
+        [PublicAPI]
         void SetWave(Wave effect);
 
         /// <summary>

--- a/Corale.Colore/Core/IMouse.cs
+++ b/Corale.Colore/Core/IMouse.cs
@@ -63,11 +63,46 @@ namespace Corale.Colore.Core
         void SetBreathing(Breathing effect);
 
         /// <summary>
+        /// Sets an effect on the mouse that causes it to breathe
+        /// between two different colors, fading to black in-between each one.
+        /// </summary>
+        /// <param name="first">First color to breathe into.</param>
+        /// <param name="second">Second color to breathe into.</param>
+        /// <param name="led">The LED(s) on which to apply the effect.</param>
+        [PublicAPI]
+        void SetBreathing(Color first, Color second, Led led = Led.All);
+
+        /// <summary>
+        /// Sets an effect on the mouse that causes it to breathe
+        /// a single color. The specified color will fade in
+        /// on the mouse, then fade to black, and repeat.
+        /// </summary>
+        /// <param name="color">The color to breathe.</param>
+        /// <param name="led">The LED(s) on which to apply the effect.</param>
+        [PublicAPI]
+        void SetBreathing(Color color, Led led = Led.All);
+
+        /// <summary>
+        /// Instructs the mouse to breathe random colors.
+        /// </summary>
+        /// <param name="led">The LED(s) on which to apply the effect.</param>
+        [PublicAPI]
+        void SetBreathing(Led led = Led.All);
+
+        /// <summary>
         /// Sets a static color on the mouse.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Static" /> effect.</param>
         [PublicAPI]
         void SetStatic(Static effect);
+
+        /// <summary>
+        /// Sets a static effect on the mouse.
+        /// </summary>
+        /// <param name="color">The color to use.</param>
+        /// <param name="led">Which LED(s) to affect.</param>
+        [PublicAPI]
+        void SetStatic(Color color, Led led = Led.All);
 
         /// <summary>
         /// Starts a blinking effect on the specified LED.
@@ -77,11 +112,28 @@ namespace Corale.Colore.Core
         void SetBlinking(Blinking effect);
 
         /// <summary>
+        /// Starts a blinking effect on the mouse.
+        /// </summary>
+        /// <param name="color">The color to blink with.</param>
+        /// <param name="led">The LED(s) to affect.</param>
+        [PublicAPI]
+        void SetBlinking(Color color, Led led = Led.All);
+
+        /// <summary>
         /// Sets a reactive effect on the mouse.
         /// </summary>
         /// <param name="effect">Effect options struct.</param>
         [PublicAPI]
         void SetReactive(Reactive effect);
+
+        /// <summary>
+        /// Sets a reactive effect on the mouse.
+        /// </summary>
+        /// <param name="duration">How long the effect should last.</param>
+        /// <param name="color">The color to react with.</param>
+        /// <param name="led">Which LED(s) to affect.</param>
+        [PublicAPI]
+        void SetReactive(Duration duration, Color color, Led led = Led.All);
 
         /// <summary>
         /// Sets a spectrum cycling effect on the mouse.
@@ -91,11 +143,25 @@ namespace Corale.Colore.Core
         void SetSpectrumCycling(SpectrumCycling effect);
 
         /// <summary>
+        /// Sets a spectrum cycling effect on the mouse.
+        /// </summary>
+        /// <param name="led">The LED(s) to affect.</param>
+        [PublicAPI]
+        void SetSpectrumCycling(Led led = Led.All);
+
+        /// <summary>
         /// Sets a wave effect on the mouse.
         /// </summary>
         /// <param name="effect">Effect options struct.</param>
         [PublicAPI]
         void SetWave(Wave effect);
+
+        /// <summary>
+        /// Sets a wave effect on the mouse.
+        /// </summary>
+        /// <param name="direction">Direction of the wave.</param>
+        [PublicAPI]
+        void SetWave(Direction direction);
 
         /// <summary>
         /// Sets a custom effect on the mouse.

--- a/Corale.Colore/Core/IMousepad.cs
+++ b/Corale.Colore/Core/IMousepad.cs
@@ -46,6 +46,21 @@ namespace Corale.Colore.Core
         void SetBreathing(Breathing effect);
 
         /// <summary>
+        /// Sets a breathing effect on the mouse pad.
+        /// </summary>
+        /// <param name="first">First color to breathe into.</param>
+        /// <param name="second">Second color to breathe into.</param>
+        [PublicAPI]
+        void SetBreathing(Color first, Color second);
+
+        /// <summary>
+        /// Sets an effect on the mouse pad that causes
+        /// it to breathe between random colors.
+        /// </summary>
+        [PublicAPI]
+        void SetBreathing();
+
+        /// <summary>
         /// Sets a static color effect on the mouse pad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Static" /> struct.</param>
@@ -53,11 +68,25 @@ namespace Corale.Colore.Core
         void SetStatic(Static effect);
 
         /// <summary>
+        /// Sets a static color effect on the mouse pad.
+        /// </summary>
+        /// <param name="color">Color to set.</param>
+        [PublicAPI]
+        void SetStatic(Color color);
+
+        /// <summary>
         /// Sets a wave effect on the mouse pad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Wave" /> struct.</param>
         [PublicAPI]
         void SetWave(Wave effect);
+
+        /// <summary>
+        /// Sets a wave effect on the mouse pad.
+        /// </summary>
+        /// <param name="direction">Direction of the wave.</param>
+        [PublicAPI]
+        void SetWave(Direction direction);
 
         /// <summary>
         /// Sets a custom effect on the mouse pad.

--- a/Corale.Colore/Core/Keypad.cs
+++ b/Corale.Colore/Core/Keypad.cs
@@ -100,6 +100,17 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Returns whether a key has had a custom color set.
+        /// </summary>
+        /// <param name="row">The row to query.</param>
+        /// <param name="column">The column to query.</param>
+        /// <returns><c>true</c> if the position has a color set that is not black, otherwise <c>false</c>.</returns>
+        public bool IsSet(int row, int column)
+        {
+            return this[row, column] != Color.Black;
+        }
+
+        /// <summary>
         /// Sets the color of all components on this device.
         /// </summary>
         /// <param name="color">Color to set.</param>
@@ -129,6 +140,26 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Sets a <see cref="Breathing" /> effect on the keypad
+        /// using the specified <see cref="Color" />.
+        /// </summary>
+        /// <param name="first">The first color to breathe into.</param>
+        /// <param name="second">Second color to breathe into.</param>
+        public void SetBreathing(Color first, Color second)
+        {
+            SetBreathing(new Breathing(first, second));
+        }
+
+        /// <summary>
+        /// Sets an effect on the keypad to breathe
+        /// between randomly chosen colors.
+        /// </summary>
+        public void SetBreathing()
+        {
+            SetBreathing(new Breathing(BreathingType.Random, Color.Black, Color.Black));
+        }
+
+        /// <summary>
         /// Sets a <see cref="Custom" /> effect on the keypad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Custom" /> struct.</param>
@@ -147,6 +178,17 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Sets a <see cref="Reactive" /> effect on the keypad
+        /// with the specified parameters.
+        /// </summary>
+        /// <param name="duration">Duration of the effect.</param>
+        /// <param name="color">Color of the effect.</param>
+        public void SetReactive(Duration duration, Color color)
+        {
+            SetReactive(new Reactive(duration, color));
+        }
+
+        /// <summary>
         /// Sets a <see cref="Static" /> effect on the keypad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Static" /> struct.</param>
@@ -156,12 +198,30 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Sets a <see cref="Static" /> effect on the keypad.
+        /// </summary>
+        /// <param name="color">Color of the effect.</param>
+        public void SetStatic(Color color)
+        {
+            SetStatic(new Static(color));
+        }
+
+        /// <summary>
         /// Sets a <see cref="Wave" /> effect on the keypad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Wave" /> struct.</param>
         public void SetWave(Wave effect)
         {
             SetGuid(NativeWrapper.CreateKeypadEffect(effect));
+        }
+
+        /// <summary>
+        /// Sets a <see cref="Wave" /> effect on the keypad.
+        /// </summary>
+        /// <param name="direction">Direction of the wave.</param>
+        public void SetWave(Direction direction)
+        {
+            SetWave(new Wave(direction));
         }
     }
 }

--- a/Corale.Colore/Core/Mouse.cs
+++ b/Corale.Colore/Core/Mouse.cs
@@ -110,12 +110,55 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Sets an effect on the mouse that causes it to breathe
+        /// between two different colors, fading to black in-between each one.
+        /// </summary>
+        /// <param name="first">First color to breathe into.</param>
+        /// <param name="second">Second color to breathe into.</param>
+        /// <param name="led">The LED(s) on which to apply the effect.</param>
+        public void SetBreathing(Color first, Color second, Led led = Led.All)
+        {
+            SetBreathing(new Breathing(led, first, second));
+        }
+
+        /// <summary>
+        /// Sets an effect on the mouse that causes it to breathe
+        /// a single color. The specified color will fade in
+        /// on the mouse, then fade to black, and repeat.
+        /// </summary>
+        /// <param name="color">The color to breathe.</param>
+        /// <param name="led">The LED(s) on which to apply the effect.</param>
+        public void SetBreathing(Color color, Led led = Led.All)
+        {
+            SetBreathing(new Breathing(led, color));
+        }
+
+        /// <summary>
+        /// Instructs the mouse to breathe random colors.
+        /// </summary>
+        /// <param name="led">The LED(s) on which to apply the effect.</param>
+        public void SetBreathing(Led led = Led.All)
+        {
+            SetBreathing(new Breathing(led));
+        }
+
+        /// <summary>
         /// Sets a static color on the mouse.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Static" /> effect.</param>
         public void SetStatic(Static effect)
         {
             SetGuid(NativeWrapper.CreateMouseEffect(effect));
+        }
+
+        /// <summary>
+        /// Sets a static effect on the mouse.
+        /// </summary>
+        /// <param name="color">The color to use.</param>
+        /// <param name="led">Which LED(s) to affect.</param>
+        public void SetStatic(Color color, Led led = Led.All)
+        {
+            SetStatic(new Static(led, color));
         }
 
         /// <summary>
@@ -128,12 +171,33 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Starts a blinking effect on the mouse.
+        /// </summary>
+        /// <param name="color">The color to blink with.</param>
+        /// <param name="led">The LED(s) to affect.</param>
+        public void SetBlinking(Color color, Led led = Led.All)
+        {
+            SetBlinking(new Blinking(led, color));
+        }
+
+        /// <summary>
         /// Sets a reactive effect on the mouse.
         /// </summary>
         /// <param name="effect">Effect options struct.</param>
         public void SetReactive(Reactive effect)
         {
             SetGuid(NativeWrapper.CreateMouseEffect(effect));
+        }
+
+        /// <summary>
+        /// Sets a reactive effect on the mouse.
+        /// </summary>
+        /// <param name="duration">How long the effect should last.</param>
+        /// <param name="color">The color to react with.</param>
+        /// <param name="led">Which LED(s) to affect.</param>
+        public void SetReactive(Duration duration, Color color, Led led = Led.All)
+        {
+            SetReactive(new Reactive(led, duration, color));
         }
 
         /// <summary>
@@ -146,12 +210,30 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Sets a spectrum cycling effect on the mouse.
+        /// </summary>
+        /// <param name="led">The LED(s) to affect.</param>
+        public void SetSpectrumCycling(Led led = Led.All)
+        {
+            SetSpectrumCycling(new SpectrumCycling(led));
+        }
+
+        /// <summary>
         /// Sets a wave effect on the mouse.
         /// </summary>
         /// <param name="effect">Effect options struct.</param>
         public void SetWave(Wave effect)
         {
             SetGuid(NativeWrapper.CreateMouseEffect(effect));
+        }
+
+        /// <summary>
+        /// Sets a wave effect on the mouse.
+        /// </summary>
+        /// <param name="direction">Direction of the wave.</param>
+        public void SetWave(Direction direction)
+        {
+            SetWave(new Wave(direction));
         }
 
         /// <summary>

--- a/Corale.Colore/Core/Mousepad.cs
+++ b/Corale.Colore/Core/Mousepad.cs
@@ -105,6 +105,25 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Sets a breathing effect on the mouse pad.
+        /// </summary>
+        /// <param name="first">First color to breathe into.</param>
+        /// <param name="second">Second color to breathe into.</param>
+        public void SetBreathing(Color first, Color second)
+        {
+            SetBreathing(new Breathing(first, second));
+        }
+
+        /// <summary>
+        /// Sets an effect on the mouse pad that causes
+        /// it to breathe between random colors.
+        /// </summary>
+        public void SetBreathing()
+        {
+            SetBreathing(new Breathing(BreathingType.Random, Color.Black, Color.Black));
+        }
+
+        /// <summary>
         /// Sets a static color effect on the mouse pad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Static" /> struct.</param>
@@ -114,12 +133,30 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Sets a static color effect on the mouse pad.
+        /// </summary>
+        /// <param name="color">Color to set.</param>
+        public void SetStatic(Color color)
+        {
+            SetStatic(new Static(color));
+        }
+
+        /// <summary>
         /// Sets a wave effect on the mouse pad.
         /// </summary>
         /// <param name="effect">An instance of the <see cref="Wave" /> struct.</param>
         public void SetWave(Wave effect)
         {
             SetGuid(NativeWrapper.CreateMousepadEffect(effect));
+        }
+
+        /// <summary>
+        /// Sets a wave effect on the mouse pad.
+        /// </summary>
+        /// <param name="direction">Direction of the wave.</param>
+        public void SetWave(Direction direction)
+        {
+            SetWave(new Wave(direction));
         }
 
         /// <summary>

--- a/Corale.Colore/Razer/Keypad/Effects/Breathing.cs
+++ b/Corale.Colore/Razer/Keypad/Effects/Breathing.cs
@@ -30,6 +30,7 @@
 
 namespace Corale.Colore.Razer.Keypad.Effects
 {
+    using Corale.Colore.Annotations;
     using Corale.Colore.Core;
 
     /// <summary>
@@ -40,16 +41,19 @@ namespace Corale.Colore.Razer.Keypad.Effects
         /// <summary>
         /// The type of breathing.
         /// </summary>
+        [UsedImplicitly]
         public BreathingType Type;
 
         /// <summary>
         /// Initial color.
         /// </summary>
+        [UsedImplicitly]
         public Color First;
 
         /// <summary>
         /// Second color.
         /// </summary>
+        [UsedImplicitly]
         public Color Second;
 
         /// <summary>

--- a/Corale.Colore/Razer/Mouse/Effects/Reactive.cs
+++ b/Corale.Colore/Razer/Mouse/Effects/Reactive.cs
@@ -32,6 +32,7 @@ namespace Corale.Colore.Razer.Mouse.Effects
 {
     using System.Runtime.InteropServices;
 
+    using Corale.Colore.Annotations;
     using Corale.Colore.Core;
 
     /// <summary>
@@ -43,16 +44,19 @@ namespace Corale.Colore.Razer.Mouse.Effects
         /// <summary>
         /// The LED on which to apply the effect.
         /// </summary>
+        [UsedImplicitly]
         public Led Led;
 
         /// <summary>
         /// Duration of the reaction.
         /// </summary>
+        [UsedImplicitly]
         public Duration Duration;
 
         /// <summary>
         /// Reaction color.
         /// </summary>
+        [UsedImplicitly]
         public Color Color;
 
         /// <summary>

--- a/Corale.Colore/Razer/Mouse/Effects/SpectrumCycling.cs
+++ b/Corale.Colore/Razer/Mouse/Effects/SpectrumCycling.cs
@@ -30,6 +30,8 @@
 
 namespace Corale.Colore.Razer.Mouse.Effects
 {
+    using Corale.Colore.Annotations;
+
     /// <summary>
     /// Spectrum cycling effect.
     /// </summary>
@@ -38,6 +40,7 @@ namespace Corale.Colore.Razer.Mouse.Effects
         /// <summary>
         /// The LED on which to apply the effect.
         /// </summary>
+        [UsedImplicitly]
         public Led Led;
 
         /// <summary>

--- a/Corale.Colore/Razer/Mouse/Effects/Wave.cs
+++ b/Corale.Colore/Razer/Mouse/Effects/Wave.cs
@@ -30,6 +30,8 @@
 
 namespace Corale.Colore.Razer.Mouse.Effects
 {
+    using Corale.Colore.Annotations;
+
     /// <summary>
     /// Wave effect.
     /// </summary>
@@ -38,6 +40,7 @@ namespace Corale.Colore.Razer.Mouse.Effects
         /// <summary>
         /// The direction of the wave effect.
         /// </summary>
+        [UsedImplicitly]
         public Direction Direction;
 
         /// <summary>

--- a/Corale.Colore/Razer/Mousepad/Effects/Breathing.cs
+++ b/Corale.Colore/Razer/Mousepad/Effects/Breathing.cs
@@ -32,6 +32,7 @@ namespace Corale.Colore.Razer.Mousepad.Effects
 {
     using System.Runtime.InteropServices;
 
+    using Corale.Colore.Annotations;
     using Corale.Colore.Core;
 
     /// <summary>
@@ -43,16 +44,19 @@ namespace Corale.Colore.Razer.Mousepad.Effects
         /// <summary>
         /// The type of breathing effect.
         /// </summary>
+        [UsedImplicitly]
         public readonly BreathingType Type;
 
         /// <summary>
         /// Initial color.
         /// </summary>
+        [UsedImplicitly]
         public readonly Color First;
 
         /// <summary>
         /// Color to "breathe into".
         /// </summary>
+        [UsedImplicitly]
         public readonly Color Second;
 
         /// <summary>

--- a/Corale.Colore/Razer/Mousepad/Effects/Static.cs
+++ b/Corale.Colore/Razer/Mousepad/Effects/Static.cs
@@ -32,6 +32,7 @@ namespace Corale.Colore.Razer.Mousepad.Effects
 {
     using System.Runtime.InteropServices;
 
+    using Corale.Colore.Annotations;
     using Corale.Colore.Core;
 
     /// <summary>
@@ -43,6 +44,7 @@ namespace Corale.Colore.Razer.Mousepad.Effects
         /// <summary>
         /// The color to use.
         /// </summary>
+        [UsedImplicitly]
         public Color Color;
 
         /// <summary>


### PR DESCRIPTION
This adds simple to use helper methods to classes that previously didn't have them.

All classes should now be on the same level of usability as the `Keyboard` class.

Implements #56 