### PR TITLE
Improve SDK detection method

### DIFF
--- a/Corale.Colore/Core/Chroma.cs
+++ b/Corale.Colore/Core/Chroma.cs
@@ -32,12 +32,15 @@ namespace Corale.Colore.Core
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
+    using System.Security;
 
     using Corale.Colore.Annotations;
     using Corale.Colore.Events;
     using Corale.Colore.Razer;
 
     using log4net;
+
+    using Microsoft.Win32;
 
     /// <summary>
     /// Main class for interacting with the Chroma SDK.
@@ -208,12 +211,57 @@ namespace Corale.Colore.Core
         [PublicAPI]
         public static bool IsSdkAvailable()
         {
-            // We try both 32-bit and 64-bit libraries
-            // If neither exist, we do not have SDK available
-            var sdk32Ptr = Native.Kernel32.NativeMethods.LoadLibrary("RzChromaSDK.dll");
-            var sdk64Ptr = Native.Kernel32.NativeMethods.LoadLibrary("RzChromaSDK64.dll");
+            bool dllValid;
+            var regKey = @"SOFTWARE\Razer Chroma SDK";
 
-            return sdk32Ptr != IntPtr.Zero || sdk64Ptr != IntPtr.Zero;
+#if ANYCPU
+            if (EnvironmentHelper.Is64BitProcess() && EnvironmentHelper.Is64BitOperatingSystem())
+            {
+                dllValid = Native.Kernel32.NativeMethods.LoadLibrary("RzChromaSDK64.dll") != IntPtr.Zero;
+                regKey = @"SOFTWARE\Wow6432Node\Razer Chroma SDK";
+            }
+            else
+                dllValid = Native.Kernel32.NativeMethods.LoadLibrary("RzChromaSDK.dll") != IntPtr.Zero;
+#elif WIN64
+            dllValid = Native.Kernel32.NativeMethods.LoadLibrary("RzChromaSDK64.dll") != IntPtr.Zero;
+            regKey = @"SOFTWARE\Wow6432Node\Razer Chroma SDK";
+#else
+            dllValid = Native.Kernel32.NativeMethods.LoadLibrary("RzChromaSDK.dll") != IntPtr.Zero;
+#endif
+
+            bool regEnabled;
+
+            try
+            {
+                using (var key = Registry.LocalMachine.OpenSubKey(regKey))
+                {
+                    if (key != null)
+                    {
+                        var value = key.GetValue("Enable");
+                        var bytes = value as byte[];
+
+                        regEnabled = bytes != null && bytes[0] == 1;
+                    }
+                    else
+                        regEnabled = false;
+                }
+            }
+            catch (SecurityException ex)
+            {
+                // If we can't access the registry, best to just assume
+                // it is enabled.
+                Log.Warn("System raised SecurityException during read of SDK enable flag in registry.", ex);
+                regEnabled = true;
+            }
+            catch (UnauthorizedAccessException ex)
+            {
+                // If we can't access the registry, best to just assume
+                // it is enabled.
+                Log.Warn("Not authorized to read registry for SDK enable flag.", ex);
+                regEnabled = true;
+            }
+
+            return dllValid && regEnabled;
         }
 
         /// <summary>


### PR DESCRIPTION
The SDK detection method will now only check for the library file relevant
for the architecture of the current system.

SDK detection method will now also check the registry to see if the SDK
has been enabled (fallback to enabled state if registry access is denied).

Fixes #83 