### PR TITLE
Fix Orange constant value.

### DIFF
--- a/Corale.Colore/Core/Color.cs
+++ b/Corale.Colore/Core/Color.cs
@@ -62,7 +62,7 @@ namespace Corale.Colore.Core
         /// <summary>
         /// Orange color.
         /// </summary>
-        public static readonly Color Orange = new Color(0xFFA500);
+        public static readonly Color Orange = new Color(0x00A5FF);
 
         /// <summary>
         /// Pink color.


### PR DESCRIPTION
When using the Color(uint) ctor, the format of the value should be 0xAABBGGRR.  The Orange color was in the more commonly known format of RRGGBB.  As such the displayed color was a light blue instead of orange.