### PR TITLE
Improvements to Color

### DIFF
--- a/Corale.Colore.Tests/Corale.Colore.Tests.csproj
+++ b/Corale.Colore.Tests/Corale.Colore.Tests.csproj
@@ -73,6 +73,7 @@
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/Corale.Colore.Tests/Core/ColorTests.cs
+++ b/Corale.Colore.Tests/Core/ColorTests.cs
@@ -34,70 +34,111 @@ namespace Corale.Colore.Tests.Core
 
     using NUnit.Framework;
 
+    using SystemColor = System.Drawing.Color;
+    using WpfColor = System.Windows.Media.Color;
+
     [TestFixture]
     public class ColorTests
     {
         [Test]
         public void ShouldConstructCorrectly()
         {
-            Assert.AreEqual(new Color(0x00123456).Value, 0x00123456);
+            Assert.AreEqual(new Color(0x78123456).Value, 0x78123456);
         }
 
         [Test]
         public void ShouldConstructFromColor()
         {
-            var c = new Color(0x00123456);
+            var c = new Color(0x78123456);
             Assert.AreEqual(new Color(c), c);
         }
 
         [Test]
         public void ShouldConvertRgbBytesCorrectly()
         {
-            const uint V = 0x00FFFFFF;
-            const byte R = 255;
-            const byte G = 255;
-            const byte B = 255;
-            var c = new Color(R, G, B);
+            const uint V = 0x8056F5C8;
+            const byte R = 200;
+            const byte G = 245;
+            const byte B = 86;
+            const byte A = 128;
+            var c = new Color(R, G, B, A);
             Assert.AreEqual(c.Value, V);
             Assert.AreEqual(c.R, R);
             Assert.AreEqual(c.G, G);
             Assert.AreEqual(c.B, B);
+            Assert.AreEqual(c.A, A);
         }
 
         [Test]
         public void ShouldConvertRgbDoublesCorrectly()
         {
-            const uint V = 0x00FFFFFF;
-            const double R = 1.0;
-            const double G = 1.0;
-            const double B = 1.0;
-            const byte Expected = 255;
-            var c = new Color(R, G, B);
+            const uint V = 0x7F3D89CC;
+            const double R = 0.8;
+            const double G = 0.54;
+            const double B = 0.24;
+            const double A = 0.5;
+            const byte ExpectedR = (byte)(R * 255);
+            const byte ExpectedG = (byte)(G * 255);
+            const byte ExpectedB = (byte)(B * 255);
+            const byte ExpectedA = (byte)(A * 255);
+            var c = new Color(R, G, B, A);
             Assert.AreEqual(c.Value, V);
-            Assert.AreEqual(c.R, Expected);
-            Assert.AreEqual(c.G, Expected);
-            Assert.AreEqual(c.B, Expected);
+            Assert.AreEqual(c.R, ExpectedR);
+            Assert.AreEqual(c.G, ExpectedG);
+            Assert.AreEqual(c.B, ExpectedB);
+            Assert.AreEqual(c.A, ExpectedA);
         }
 
         [Test]
         public void ShouldConvertRgbFloatsCorrectly()
         {
-            const uint V = 0x00FFFFFF;
-            const float R = 1.0f;
-            const float G = 1.0f;
-            const float B = 1.0f;
-            const byte Expected = 255;
-            var c = new Color(R, G, B);
+            const uint V = 0xD8E533CC;
+            const float R = 0.8f;
+            const float G = 0.2f;
+            const float B = 0.9f;
+            const float A = 0.85f;
+            const byte ExpectedR = (byte)(R * 255);
+            const byte ExpectedG = (byte)(G * 255);
+            const byte ExpectedB = (byte)(B * 255);
+            const byte ExpectedA = (byte)(A * 255);
+            var c = new Color(R, G, B, A);
             Assert.AreEqual(c.Value, V);
-            Assert.AreEqual(c.R, Expected);
-            Assert.AreEqual(c.G, Expected);
-            Assert.AreEqual(c.B, Expected);
+            Assert.AreEqual(c.R, ExpectedR);
+            Assert.AreEqual(c.G, ExpectedG);
+            Assert.AreEqual(c.B, ExpectedB);
+            Assert.AreEqual(c.A, ExpectedA);
         }
 
         [Test]
-        public void ShouldDefaultToBlackColor()
+        public void ShouldConstructFromArgb()
         {
-            Assert.AreEqual(new Color(), Color.Black);
+            var expected = new Color(0x12345678);
+            var actual = Color.FromArgb(0x12785634);
+
+            Assert.AreEqual(expected.Value, actual.Value);
+            Assert.AreEqual(expected.R, actual.R);
+            Assert.AreEqual(expected.G, actual.G);
+            Assert.AreEqual(expected.B, actual.B);
+            Assert.AreEqual(expected.A, actual.A);
+        }
+
+        [Test]
+        public void ShouldConstructFromRgb()
+        {
+            var expected = new Color(0xFF123456);
+            var actual = Color.FromRgb(0x563412);
+
+            Assert.AreEqual(expected.Value, actual.Value);
+            Assert.AreEqual(expected.R, actual.R);
+            Assert.AreEqual(expected.G, actual.G);
+            Assert.AreEqual(expected.B, actual.B);
+            Assert.AreEqual(expected.A, actual.A);
+        }
+
+        [Test]
+        public void ShouldDefaultToEmptyColor()
+        {
+            Assert.AreEqual(new Color().Value, 0);
         }
 
         [Test]
@@ -114,7 +155,7 @@ namespace Corale.Colore.Tests.Core
         public void ShouldEqualIdenticalUint()
         {
             var a = new Color(255, 0, 255);
-            const uint B = 0x00FF00FF;
+            const uint B = 0xFFFF00FF;
             Assert.AreEqual(a, B);
             Assert.True(a == B);
             Assert.False(a != B);
@@ -206,46 +247,143 @@ namespace Corale.Colore.Tests.Core
         }
 
         [Test]
-        public void ShouldConstructFromSystemColor()
+        public void ShouldConvertFromSystemColor()
         {
-            var source = System.Drawing.Color.FromArgb(5, 10, 15);
-            var coloreColor = new Color(source);
+            var source = SystemColor.FromArgb(5, 10, 15, 20);
+            var coloreColor = Color.FromSystemColor(source);
 
             Assert.AreEqual(source.R, coloreColor.R);
             Assert.AreEqual(source.G, coloreColor.G);
             Assert.AreEqual(source.B, coloreColor.B);
+            Assert.AreEqual(source.A, coloreColor.A);
         }
 
         [Test]
-        public void ShouldConvertToSystemColor()
+        public void ShouldExplicitCastToSystemColor()
         {
-            var coloreColor = new Color(1, 2, 4);
-            var systemColor = (System.Drawing.Color)coloreColor;
+            var coloreColor = new Color(1, 2, 4, 8);
+            var systemColor = (SystemColor)coloreColor;
 
             Assert.AreEqual(coloreColor.R, systemColor.R);
             Assert.AreEqual(coloreColor.G, systemColor.G);
             Assert.AreEqual(coloreColor.B, systemColor.B);
+            Assert.AreEqual(coloreColor.A, systemColor.A);
         }
 
         [Test]
-        public void ShouldConvertFromSystemColor()
+        public void ShouldExplicitCastFromSystemColor()
         {
-            var systemColor = System.Drawing.Color.FromArgb(5, 10, 15);
+            var systemColor = SystemColor.FromArgb(5, 10, 15, 20);
             var coloreColor = (Color)systemColor;
 
             Assert.AreEqual(systemColor.R, coloreColor.R);
             Assert.AreEqual(systemColor.G, coloreColor.G);
             Assert.AreEqual(systemColor.B, coloreColor.B);
+            Assert.AreEqual(systemColor.A, coloreColor.A);
+        }
+
+        [Test]
+        public void ShouldImplicitCastToSystemColor()
+        {
+            var coloreColor = new Color(1, 2, 4, 8);
+            SystemColor systemColor = coloreColor;
+
+            Assert.AreEqual(coloreColor.R, systemColor.R);
+            Assert.AreEqual(coloreColor.G, systemColor.G);
+            Assert.AreEqual(coloreColor.B, systemColor.B);
+            Assert.AreEqual(coloreColor.A, systemColor.A);
+        }
+
+        [Test]
+        public void ShouldImplicitCastFromSystemColor()
+        {
+            var systemColor = SystemColor.FromArgb(5, 10, 15, 20);
+            Color coloreColor = systemColor;
+
+            Assert.AreEqual(systemColor.R, coloreColor.R);
+            Assert.AreEqual(systemColor.G, coloreColor.G);
+            Assert.AreEqual(systemColor.B, coloreColor.B);
+            Assert.AreEqual(systemColor.A, coloreColor.A);
         }
 
         [Test]
         public void ShouldEqualSystemColorUsingOverload()
         {
-            var coloreColor = new Color(1, 2, 3);
-            var systemColor = System.Drawing.Color.FromArgb(1, 2, 3);
+            var coloreColor = new Color(1, 2, 3, 8);
+            var systemColor = SystemColor.FromArgb(8, 1, 2, 3);
 
             Assert.True(coloreColor.Equals(systemColor));
             Assert.AreEqual(coloreColor, systemColor);
+        }
+
+        [Test]
+        public void ShouldConvertFromWpfColor()
+        {
+            var wpfColor = WpfColor.FromArgb(5, 10, 15, 20);
+            var coloreColor = Color.FromWpfColor(wpfColor);
+
+            Assert.AreEqual(wpfColor.R, coloreColor.R);
+            Assert.AreEqual(wpfColor.G, coloreColor.G);
+            Assert.AreEqual(wpfColor.B, coloreColor.B);
+            Assert.AreEqual(wpfColor.A, coloreColor.A);
+        }
+
+        [Test]
+        public void ShouldExplicitCastToWpfColor()
+        {
+            var coloreColor = new Color(1, 2, 4, 8);
+            var wpfColor = (WpfColor)coloreColor;
+
+            Assert.AreEqual(coloreColor.R, wpfColor.R);
+            Assert.AreEqual(coloreColor.G, wpfColor.G);
+            Assert.AreEqual(coloreColor.B, wpfColor.B);
+            Assert.AreEqual(coloreColor.A, wpfColor.A);
+        }
+
+        [Test]
+        public void ShouldExplicitCastFromWpfColor()
+        {
+            var wpfColor = WpfColor.FromArgb(5, 10, 15, 20);
+            var coloreColor = (Color)wpfColor;
+
+            Assert.AreEqual(wpfColor.R, coloreColor.R);
+            Assert.AreEqual(wpfColor.G, coloreColor.G);
+            Assert.AreEqual(wpfColor.B, coloreColor.B);
+            Assert.AreEqual(wpfColor.A, coloreColor.A);
+        }
+
+        [Test]
+        public void ShouldImplicitCastToWpfColor()
+        {
+            var coloreColor = new Color(1, 2, 4, 8);
+            WpfColor wpfColor = coloreColor;
+
+            Assert.AreEqual(coloreColor.R, wpfColor.R);
+            Assert.AreEqual(coloreColor.G, wpfColor.G);
+            Assert.AreEqual(coloreColor.B, wpfColor.B);
+            Assert.AreEqual(coloreColor.A, wpfColor.A);
+        }
+
+        [Test]
+        public void ShouldImplicitCastFromWpfColor()
+        {
+            var wpfColor = WpfColor.FromArgb(5, 10, 15, 20);
+            Color coloreColor = wpfColor;
+
+            Assert.AreEqual(wpfColor.R, coloreColor.R);
+            Assert.AreEqual(wpfColor.G, coloreColor.G);
+            Assert.AreEqual(wpfColor.B, coloreColor.B);
+            Assert.AreEqual(wpfColor.A, coloreColor.A);
+        }
+
+        [Test]
+        public void ShouldEqualWpfColorUsingOverload()
+        {
+            var coloreColor = new Color(1, 2, 3, 8);
+            var wpfColor = WpfColor.FromArgb(8, 1, 2, 3);
+
+            Assert.True(coloreColor.Equals(wpfColor));
+            Assert.AreEqual(coloreColor, wpfColor);
         }
     }
 }

--- a/Corale.Colore/Corale.Colore.csproj
+++ b/Corale.Colore/Corale.Colore.csproj
@@ -91,6 +91,7 @@
     <Compile Include="ColoreException.cs" />
     <Compile Include="Core\Chroma.cs" />
     <Compile Include="Core\Color.cs" />
+    <Compile Include="Core\Color.Defines.cs" />
     <Compile Include="Core\Device.cs" />
     <Compile Include="Core\Device.Obsoletes.cs" />
     <Compile Include="Core\GenericDevice.Obsoletes.cs" />

--- a/Corale.Colore/Corale.Colore.csproj
+++ b/Corale.Colore/Corale.Colore.csproj
@@ -79,6 +79,7 @@
       <HintPath>..\packages\log4net.2.0.3\lib\net35-full\log4net.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/Corale.Colore/Core/Color.Defines.cs
+++ b/Corale.Colore/Core/Color.Defines.cs
@@ -1,0 +1,100 @@
+﻿// ---------------------------------------------------------------------------------------
+// <copyright file="Color.Defines.cs" company="Corale">
+//     Copyright © 2015 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     Disclaimer: Corale and/or Colore is in no way affiliated with Razer and/or any
+//     of its employees and/or licensors. Corale, Adam Hellberg, and/or Brandon Scott
+//     do not take responsibility for any harm caused, direct or indirect, to any
+//     Razer peripherals via the use of Colore.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+// ---------------------------------------------------------------------------------------
+
+namespace Corale.Colore.Core
+{
+    using Corale.Colore.Annotations;
+
+    /// <summary>
+    /// Represents an RGB color.
+    /// </summary>
+    public partial struct Color
+    {
+        /// <summary>
+        /// Black color.
+        /// </summary>
+        [PublicAPI]
+        public static readonly Color Black = new Color(0, 0, 0);
+
+        /// <summary>
+        /// (Dark) blue color.
+        /// </summary>
+        [PublicAPI]
+        public static readonly Color Blue = new Color(0, 0, 255);
+
+        /// <summary>
+        /// (Neon/bright) green color.
+        /// </summary>
+        [PublicAPI]
+        public static readonly Color Green = new Color(0, 255, 0);
+
+        /// <summary>
+        /// Hot pink color.
+        /// </summary>
+        [PublicAPI]
+        public static readonly Color HotPink = new Color(255, 105, 180);
+
+        /// <summary>
+        /// Orange color.
+        /// </summary>
+        [PublicAPI]
+        public static readonly Color Orange = FromRgb(0xFFA500);
+
+        /// <summary>
+        /// Pink color.
+        /// </summary>
+        [PublicAPI]
+        public static readonly Color Pink = new Color(255, 0, 255);
+
+        /// <summary>
+        /// Purple color.
+        /// </summary>
+        [PublicAPI]
+        public static readonly Color Purple = FromRgb(0x800080);
+
+        /// <summary>
+        /// Red color.
+        /// </summary>
+        [PublicAPI]
+        public static readonly Color Red = new Color(255, 0, 0);
+
+        /// <summary>
+        /// White color.
+        /// </summary>
+        [PublicAPI]
+        public static readonly Color White = new Color(255, 255, 255);
+
+        /// <summary>
+        /// Yellow color.
+        /// </summary>
+        [PublicAPI]
+        public static readonly Color Yellow = new Color(255, 255, 0);
+    }
+}

--- a/Corale.Colore/Core/Color.cs
+++ b/Corale.Colore/Core/Color.cs
@@ -36,12 +36,13 @@ namespace Corale.Colore.Core
     using Corale.Colore.Annotations;
 
     using SystemColor = System.Drawing.Color;
+    using WpfColor = System.Windows.Media.Color;
 
     /// <summary>
     /// Represents an RGB color.
     /// </summary>
     [StructLayout(LayoutKind.Sequential, Size = sizeof(uint))]
-    public struct Color : IEquatable<Color>, IEquatable<uint>, IEquatable<System.Drawing.Color>
+    public partial struct Color : IEquatable<Color>, IEquatable<uint>, IEquatable<SystemColor>, IEquatable<WpfColor>
     {
         /// <summary>
         /// Internal color value.
@@ -220,8 +221,30 @@ namespace Corale.Colore.Core
         {
             return FromSystemColor(color);
         }
+
+        /// <summary>
+        /// Converts a <see cref="Color" /> struct to a <see cref="System.Windows.Media.Color" /> struct.
+        /// </summary>
+        /// <param name="color">The <see cref="Color" /> to convert.</param>
+        /// <returns>
+        /// An instance of <see cref="System.Windows.Media.Color" /> representing the
+        /// value of the <paramref name="color" /> argument.
+        /// </returns>
+        public static implicit operator WpfColor(Color color)
         {
-            return new Color(color.R, color.G, color.B, color.A);
+            return WpfColor.FromArgb(color.A, color.R, color.G, color.B);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="System.Windows.Media.Color" /> struct to a <see cref="Color" /> struct.
+        /// </summary>
+        /// <param name="color">The <see cref="System.Windows.Media.Color" /> to convert.</param>
+        /// <returns>
+        /// An instance of <see cref="Color" /> representing the value of the <paramref name="color" /> argument.
+        /// </returns>
+        public static implicit operator Color(WpfColor color)
+        {
+            return FromWpfColor(color);
         }
 
         /// <summary>
@@ -254,6 +277,18 @@ namespace Corale.Colore.Core
         /// <returns>A new instance of the <see cref="Color" /> struct.</returns>
         [PublicAPI]
         public static Color FromSystemColor(SystemColor source)
+        {
+            return new Color(source.R, source.G, source.B, source.A);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Color" /> from the source
+        /// <see cref="System.Windows.Media.Color" />.
+        /// </summary>
+        /// <param name="source">The source object to construct color from.</param>
+        /// <returns>A new instance of the <see cref="Color" /> struct.</returns>
+        [PublicAPI]
+        public static Color FromWpfColor(WpfColor source)
         {
             return new Color(source.R, source.G, source.B, source.A);
         }
@@ -305,6 +340,9 @@ namespace Corale.Colore.Core
             if (other is SystemColor)
                 return Equals((SystemColor)other);
 
+            if (other is WpfColor)
+                return Equals((WpfColor)other);
+
             return false;
         }
 
@@ -341,6 +379,17 @@ namespace Corale.Colore.Core
         public bool Equals(SystemColor other)
         {
             return R == other.R && G == other.G && B == other.B && A == other.A;
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to an instance of a
+        /// <see cref="System.Windows.Media.Color" /> struct.
+        /// </summary>
+        /// <param name="other">An instance of <see cref="System.Windows.Media.Color" /> to compare with this object.</param>
+        /// <returns><c>true</c> if the current object is equal to the <paramref name="other" /> parameter; otherwise, <c>false</c>.</returns>
+        public bool Equals(WpfColor other)
+        {
+            return R == other.R && G == other.G && B == other.B & A == other.A;
         }
 
         /// <summary>

--- a/Corale.Colore/Core/Color.cs
+++ b/Corale.Colore/Core/Color.cs
@@ -114,16 +114,6 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Color" /> struct using
-        /// a <see cref="System.Drawing.Color" /> struct as the source.
-        /// </summary>
-        /// <param name="source">An instance of the <see cref="System.Drawing.Color" /> struct.</param>
-        public Color(System.Drawing.Color source)
-            : this(source.R, source.G, source.B, source.A)
-        {
-        }
-
-        /// <summary>
         /// Gets the alpha component of the color as a byte.
         /// </summary>
         [PublicAPI]
@@ -214,7 +204,7 @@ namespace Corale.Colore.Core
         /// An instance of <see cref="System.Drawing.Color" /> representing the
         /// value of the <paramref name="color" /> argument.
         /// </returns>
-        public static explicit operator System.Drawing.Color(Color color)
+        public static implicit operator SystemColor(Color color)
         {
             return SystemColor.FromArgb(color.A, color.R, color.G, color.B);
         }
@@ -226,11 +216,10 @@ namespace Corale.Colore.Core
         /// <returns>
         /// An instance of <see cref="Color" /> representing the value of the <paramref name="color" /> argument.
         /// </returns>
-        /// <remarks>
-        /// This is an explicit cast since the alpha component of the <see cref="System.Drawing.Color" />
-        /// struct is discarded.
-        /// </remarks>
-        public static explicit operator Color(System.Drawing.Color color)
+        public static implicit operator Color(SystemColor color)
+        {
+            return FromSystemColor(color);
+        }
         {
             return new Color(color.R, color.G, color.B, color.A);
         }
@@ -255,6 +244,18 @@ namespace Corale.Colore.Core
         public static bool operator !=(Color left, object right)
         {
             return !left.Equals(right);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Color" /> from the source
+        /// <see cref="System.Drawing.Color" />.
+        /// </summary>
+        /// <param name="source">The source object to construct color from.</param>
+        /// <returns>A new instance of the <see cref="Color" /> struct.</returns>
+        [PublicAPI]
+        public static Color FromSystemColor(SystemColor source)
+        {
+            return new Color(source.R, source.G, source.B, source.A);
         }
 
         /// <summary>

--- a/Corale.Colore/Core/Color.cs
+++ b/Corale.Colore/Core/Color.cs
@@ -42,56 +42,6 @@ namespace Corale.Colore.Core
     public struct Color : IEquatable<Color>, IEquatable<uint>, IEquatable<System.Drawing.Color>
     {
         /// <summary>
-        /// Black color.
-        /// </summary>
-        public static readonly Color Black = new Color(0, 0, 0);
-
-        /// <summary>
-        /// (Dark) blue color.
-        /// </summary>
-        public static readonly Color Blue = new Color(0, 0, 255);
-
-        /// <summary>
-        /// (Neon/bright) green color.
-        /// </summary>
-        public static readonly Color Green = new Color(0, 255, 0);
-
-        /// <summary>
-        /// Hot pink color.
-        /// </summary>
-        public static readonly Color HotPink = new Color(255, 105, 180);
-
-        /// <summary>
-        /// Orange color.
-        /// </summary>
-        public static readonly Color Orange = new Color(0x00A5FF);
-
-        /// <summary>
-        /// Pink color.
-        /// </summary>
-        public static readonly Color Pink = new Color(255, 0, 255);
-
-        /// <summary>
-        /// Purple color.
-        /// </summary>
-        public static readonly Color Purple = new Color(0x800080);
-
-        /// <summary>
-        /// Red color.
-        /// </summary>
-        public static readonly Color Red = new Color(255, 0, 0);
-
-        /// <summary>
-        /// White color.
-        /// </summary>
-        public static readonly Color White = new Color(255, 255, 255);
-
-        /// <summary>
-        /// Yellow color.
-        /// </summary>
-        public static readonly Color Yellow = new Color(255, 255, 0);
-
-        /// <summary>
         /// Internal color value.
         /// </summary>
         /// <remarks>

--- a/Corale.Colore/Core/Color.cs
+++ b/Corale.Colore/Core/Color.cs
@@ -35,6 +35,8 @@ namespace Corale.Colore.Core
 
     using Corale.Colore.Annotations;
 
+    using SystemColor = System.Drawing.Color;
+
     /// <summary>
     /// Represents an RGB color.
     /// </summary>
@@ -218,7 +220,7 @@ namespace Corale.Colore.Core
         /// </remarks>
         public static explicit operator System.Drawing.Color(Color color)
         {
-            return System.Drawing.Color.FromArgb(color.A, color.R, color.G, color.B);
+            return SystemColor.FromArgb(color.A, color.R, color.G, color.B);
         }
 
         /// <summary>
@@ -303,8 +305,8 @@ namespace Corale.Colore.Core
             if (other is uint)
                 return Equals((uint)other);
 
-            if (other is System.Drawing.Color)
-                return Equals((System.Drawing.Color)other);
+            if (other is SystemColor)
+                return Equals((SystemColor)other);
 
             return false;
         }
@@ -339,7 +341,7 @@ namespace Corale.Colore.Core
         /// <c>true</c> if the current object is equal to the <paramref name="other"/> parameter; otherwise, <c>false</c>.
         /// </returns>
         /// <param name="other">An instance of <see cref="System.Drawing.Color" /> to compare with this object.</param>
-        public bool Equals(System.Drawing.Color other)
+        public bool Equals(SystemColor other)
         {
             // Do not require matching alpha values for now, as it seems Razer do
             // not properly support alpha yet.

--- a/Corale.Colore/Core/Color.cs
+++ b/Corale.Colore/Core/Color.cs
@@ -354,7 +354,7 @@ namespace Corale.Colore.Core
         /// <returns><c>true</c> of the two are equal, false otherwise.</returns>
         public bool Equals(Color other)
         {
-            return _value.Equals(other);
+            return _value.Equals(other._value);
         }
 
         /// <summary>

--- a/Corale.Colore/Core/Color.cs
+++ b/Corale.Colore/Core/Color.cs
@@ -214,10 +214,6 @@ namespace Corale.Colore.Core
         /// An instance of <see cref="System.Drawing.Color" /> representing the
         /// value of the <paramref name="color" /> argument.
         /// </returns>
-        /// <remarks>
-        /// This is an explicit cast since casting a <see cref="System.Drawing.Color" /> struct to <see cref="Color" />
-        /// is explicit.
-        /// </remarks>
         public static explicit operator System.Drawing.Color(Color color)
         {
             return SystemColor.FromArgb(color.A, color.R, color.G, color.B);
@@ -343,10 +339,7 @@ namespace Corale.Colore.Core
         /// <param name="other">An instance of <see cref="System.Drawing.Color" /> to compare with this object.</param>
         public bool Equals(SystemColor other)
         {
-            // Do not require matching alpha values for now, as it seems Razer do
-            // not properly support alpha yet.
-            // TODO: Change this back when Razer implements alpha
-            return R == other.R && G == other.G && B == other.B; // && A == other.A;
+            return R == other.R && G == other.G && B == other.B && A == other.A;
         }
 
         /// <summary>

--- a/Corale.Colore/Core/Color.cs
+++ b/Corale.Colore/Core/Color.cs
@@ -297,6 +297,33 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Creates a new <see cref="Color" /> from an ARGB integer value
+        /// in the format of <c>0xAARRGGBB</c> where the alpha component
+        /// ranges from <c>0x00</c> (fully transparent) to <c>0xFF</c> (fully opaque).
+        /// </summary>
+        /// <param name="value">The ARGB value to convert from.</param>
+        /// <returns>A new instance of the <see cref="Color" /> struct.</returns>
+        [PublicAPI]
+        public static Color FromArgb(uint value)
+        {
+            var abgr = (value & 0xFF00FF00) | ((value & 0xFF0000) >> 16) | ((value & 0xFF) << 16);
+            return new Color(abgr);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Color" /> from an RGB integer value
+        /// in the format of <c>0xRRGGBB</c>.
+        /// </summary>
+        /// <param name="value">The RGB value to convert from.</param>
+        /// <returns>A new instance of the <see cref="Color" /> struct.</returns>
+        [PublicAPI]
+        public static Color FromRgb(uint value)
+        {
+            var abgr = 0xFF000000 | ((value & 0xFF0000) >> 16) | (value & 0xFF00) | ((value & 0xFF) << 16);
+            return new Color(abgr);
+        }
+
+        /// <summary>
         /// Returns a value indicating whether this instance of <see cref="Color" />
         /// is equal to an <see cref="object" /> <paramref name="other" />.
         /// </summary>

--- a/Corale.Colore/Core/Color.cs
+++ b/Corale.Colore/Core/Color.cs
@@ -104,6 +104,7 @@ namespace Corale.Colore.Core
         /// color value in the format <c>0xAABBGGRR</c>.
         /// </summary>
         /// <param name="value">Value to create the color from.</param>
+        [PublicAPI]
         public Color(uint value)
         {
             _value = value;
@@ -118,6 +119,7 @@ namespace Corale.Colore.Core
         /// <param name="green">The green component.</param>
         /// <param name="blue">The blue component.</param>
         /// <param name="alpha">The alpha component (<c>0</c> = fully opaque).</param>
+        [PublicAPI]
         public Color(byte red, byte green, byte blue, byte alpha = 0)
             : this(red + ((uint)green << 8) + ((uint)blue << 16) + ((uint)alpha << 24))
         {
@@ -135,6 +137,7 @@ namespace Corale.Colore.Core
         /// <remarks>
         /// Each parameter value must be between <c>0.0f</c> and <c>1.0f</c> (inclusive).
         /// </remarks>
+        [PublicAPI]
         public Color(float red, float green, float blue, float alpha = 0.0f)
             : this((byte)(red * 255), (byte)(green * 255), (byte)(blue * 255), (byte)(alpha * 255))
         {
@@ -151,6 +154,7 @@ namespace Corale.Colore.Core
         /// <remarks>
         /// Each parameter value must be between <c>0.0</c> and <c>1.0</c> (inclusive).
         /// </remarks>
+        [PublicAPI]
         public Color(double red, double green, double blue, double alpha = 0.0)
             : this((byte)(red * 255), (byte)(green * 255), (byte)(blue * 255), (byte)(alpha * 255))
         {

--- a/Corale.Colore/Core/Color.cs
+++ b/Corale.Colore/Core/Color.cs
@@ -101,7 +101,8 @@ namespace Corale.Colore.Core
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Color" /> struct using an integer
-        /// color value in the format <c>0xAABBGGRR</c>.
+        /// color value in the format <c>0xAABBGGRR</c>. Where the alpha component ranges
+        /// from <c>0x00</c> (fully transparent) to <c>0xFF</c> (fully opaque).
         /// </summary>
         /// <param name="value">Value to create the color from.</param>
         [PublicAPI]
@@ -120,7 +121,7 @@ namespace Corale.Colore.Core
         /// <param name="blue">The blue component.</param>
         /// <param name="alpha">The alpha component (<c>0</c> = fully opaque).</param>
         [PublicAPI]
-        public Color(byte red, byte green, byte blue, byte alpha = 0)
+        public Color(byte red, byte green, byte blue, byte alpha = 255)
             : this(red + ((uint)green << 8) + ((uint)blue << 16) + ((uint)alpha << 24))
         {
         }
@@ -138,7 +139,7 @@ namespace Corale.Colore.Core
         /// Each parameter value must be between <c>0.0f</c> and <c>1.0f</c> (inclusive).
         /// </remarks>
         [PublicAPI]
-        public Color(float red, float green, float blue, float alpha = 0.0f)
+        public Color(float red, float green, float blue, float alpha = 1.0f)
             : this((byte)(red * 255), (byte)(green * 255), (byte)(blue * 255), (byte)(alpha * 255))
         {
         }
@@ -155,7 +156,7 @@ namespace Corale.Colore.Core
         /// Each parameter value must be between <c>0.0</c> and <c>1.0</c> (inclusive).
         /// </remarks>
         [PublicAPI]
-        public Color(double red, double green, double blue, double alpha = 0.0)
+        public Color(double red, double green, double blue, double alpha = 1.0)
             : this((byte)(red * 255), (byte)(green * 255), (byte)(blue * 255), (byte)(alpha * 255))
         {
         }
@@ -220,7 +221,7 @@ namespace Corale.Colore.Core
 
         /// <summary>
         /// Gets the unsigned integer representing
-        /// the color. On the form <c>0x00BBGGRR</c>.
+        /// the color. On the form <c>0xAABBGGRR</c>.
         /// </summary>
         [PublicAPI]
         public uint Value
@@ -236,14 +237,15 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="color">The <see cref="Color" /> to convert.</param>
         /// <returns>A <see cref="uint" /> representing the value of the <paramref name="color" /> argument.</returns>
-        /// <remarks>The returned <see cref="uint" /> has a format of <c>0x00BBGGRR</c>.</remarks>
+        /// <remarks>The returned <see cref="uint" /> has a format of <c>0xAABBGGRR</c>.</remarks>
         public static implicit operator uint(Color color)
         {
             return color._value;
         }
 
         /// <summary>
-        /// Converts <paramref name="value" /> to an instance of the <see cref="Color" /> struct.
+        /// Converts a <c>uint</c> <paramref name="value" /> in the format of <c>0xAABBGGRR</c>
+        /// to a new instance of the <see cref="Color" /> struct.
         /// </summary>
         /// <param name="value">The <see cref="uint" /> to convert, on the form <c>0x00BBGGRR</c>.</param>
         /// <returns>An instance of <see cref="Color" /> representing the color value of <paramref name="value" />.</returns>

--- a/Corale.Colore/Core/Color.cs
+++ b/Corale.Colore/Core/Color.cs
@@ -33,6 +33,8 @@ namespace Corale.Colore.Core
     using System;
     using System.Runtime.InteropServices;
 
+    using Corale.Colore.Annotations;
+
     /// <summary>
     /// Represents an RGB color.
     /// </summary>
@@ -167,6 +169,7 @@ namespace Corale.Colore.Core
         /// <summary>
         /// Gets the alpha component of the color as a byte.
         /// </summary>
+        [PublicAPI]
         public byte A
         {
             get
@@ -178,6 +181,7 @@ namespace Corale.Colore.Core
         /// <summary>
         /// Gets the blue component of the color as a byte.
         /// </summary>
+        [PublicAPI]
         public byte B
         {
             get
@@ -189,6 +193,7 @@ namespace Corale.Colore.Core
         /// <summary>
         /// Gets the green component of the color as a byte.
         /// </summary>
+        [PublicAPI]
         public byte G
         {
             get
@@ -200,6 +205,7 @@ namespace Corale.Colore.Core
         /// <summary>
         /// Gets the red component of the color as a byte.
         /// </summary>
+        [PublicAPI]
         public byte R
         {
             get
@@ -212,6 +218,7 @@ namespace Corale.Colore.Core
         /// Gets the unsigned integer representing
         /// the color. On the form <c>0x00BBGGRR</c>.
         /// </summary>
+        [PublicAPI]
         public uint Value
         {
             get


### PR DESCRIPTION
 * Adds support for `System.Windows.Media.Color` (WPF).
 * Casting between Color <=> {System.Drawing.Color, System.Windows.Media.Color} is now implicit since alpha values are now preserved.
 * `0xFF` is now treated as opaque internally in the Color struct, and `0x00` as transparent\*.
 * Added `PublicAPI` attributes to some properties, constructors, and methods.
 * Moved color definitions to their own file for easier management.
 * Alpha values are now considered in conversion and comparison.
 * Updated unit tests for new changes.

\*: Since Razer has said they do not support alpha, it should be safe for us to store alpha information in the 4th bit of the color value for conversion purposes, as *Razer should be ignoring this value anyway due to them having said they do not currently support alpha*.

Input/more information on the above note is appreciated.

### Dependency on `PresentationCore`

Will the dependency on `PresentationCore` (`System.Windows.Media`) create problems?