### PR TITLE
Fixes the Mouse Effect Enum

### DIFF
--- a/Corale.Colore/Razer/Mouse/Effects/Effect.cs
+++ b/Corale.Colore/Razer/Mouse/Effects/Effect.cs
@@ -60,6 +60,12 @@ namespace Corale.Colore.Razer.Mouse.Effects
         /// </summary>
         [PublicAPI]
         Custom,
+        
+        /// <summary>
+        /// Custom grid effect.
+        /// </summary>
+        [PublicAPI]
+        CustomGrid,
 
         /// <summary>
         /// Reactive effect.
@@ -84,13 +90,7 @@ namespace Corale.Colore.Razer.Mouse.Effects
         /// </summary>
         [PublicAPI]
         Wave,
-
-        /// <summary>
-        /// Custom grid effect.
-        /// </summary>
-        [PublicAPI]
-        CustomGrid,
-
+        
         /// <summary>
         /// Invalid effect.
         /// </summary>

--- a/Corale.Colore/Razer/Mouse/Effects/Effect.cs
+++ b/Corale.Colore/Razer/Mouse/Effects/Effect.cs
@@ -60,7 +60,7 @@ namespace Corale.Colore.Razer.Mouse.Effects
         /// </summary>
         [PublicAPI]
         Custom,
-        
+
         /// <summary>
         /// Custom grid effect.
         /// </summary>
@@ -90,7 +90,7 @@ namespace Corale.Colore.Razer.Mouse.Effects
         /// </summary>
         [PublicAPI]
         Wave,
-        
+
         /// <summary>
         /// Invalid effect.
         /// </summary>


### PR DESCRIPTION
The Mouse Effect Enum was in the wrong order causing everything below Custom to not work as expected (including SetAll which accesses CustomGrid). Custom2 (CustomGrid) needs to be beneath Custom.

From the official Type definition:

```c++
 typedef enum EFFECT_TYPE
        {
            CHROMA_NONE = 0,            //!< No effect.
            CHROMA_BLINKING,            //!< Blinking effect.
            CHROMA_BREATHING,           //!< Breathing effect.
            CHROMA_CUSTOM,              //!< Custom effect (old definition to maintain backward compatibility).
            CHROMA_CUSTOM2,             //!< Custom effects using a virtual grid.
            CHROMA_REACTIVE,            //!< Reactive effect.
            CHROMA_SPECTRUMCYCLING,     //!< Spectrum cycling effect.
            CHROMA_STATIC,              //!< Static effect.
            CHROMA_WAVE,                //!< Wave effect.
            CHROMA_INVALID              //!< Invalid effect.
        } EFFECT_TYPE;
```
