### PR TITLE
Fix ordering of mouse effect enum

### DIFF
--- a/Corale.Colore/Razer/Mouse/Effects/Effect.cs
+++ b/Corale.Colore/Razer/Mouse/Effects/Effect.cs
@@ -62,12 +62,6 @@ namespace Corale.Colore.Razer.Mouse.Effects
         Custom,
 
         /// <summary>
-        /// Custom grid effect.
-        /// </summary>
-        [PublicAPI]
-        CustomGrid,
-
-        /// <summary>
         /// Reactive effect.
         /// </summary>
         [PublicAPI]
@@ -90,6 +84,12 @@ namespace Corale.Colore.Razer.Mouse.Effects
         /// </summary>
         [PublicAPI]
         Wave,
+
+        /// <summary>
+        /// Custom grid effect.
+        /// </summary>
+        [PublicAPI]
+        CustomGrid,
 
         /// <summary>
         /// Invalid effect.


### PR DESCRIPTION
This moves `CustomGrid` effect from below `Custom` to the last effect (before `Invalid`).

As specified by SDK version 1.1.2/1.1.5.

Fixes #125.