### PR TITLE
Add BreathingType to Keyboard Breathing Effect

### DIFF
--- a/Corale.Colore/Corale.Colore.csproj
+++ b/Corale.Colore/Corale.Colore.csproj
@@ -126,6 +126,7 @@
     <Compile Include="Razer\Keyboard\Constants.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Razer\Keyboard\Effects\Breathing.cs" />
+    <Compile Include="Razer\Keyboard\Effects\BreathingType.cs" />
     <Compile Include="Razer\Keyboard\Effects\Custom.cs" />
     <Compile Include="Razer\Keyboard\Effects\Direction.cs" />
     <Compile Include="Razer\Keyboard\Effects\Duration.cs" />

--- a/Corale.Colore/Core/IKeyboard.cs
+++ b/Corale.Colore/Core/IKeyboard.cs
@@ -84,6 +84,13 @@ namespace Corale.Colore.Core
         void SetBreathing(Color first, Color second);
 
         /// <summary>
+        /// Sets an effect on the keyboard, fading between
+        /// between randomly chosen colors.
+        /// </summary>
+        [PublicAPI]
+        void SetBreathing();
+
+        /// <summary>
         /// Sets a reactive effect on the keyboard with the specified
         /// color and duration.
         /// </summary>

--- a/Corale.Colore/Core/Keyboard.cs
+++ b/Corale.Colore/Core/Keyboard.cs
@@ -216,6 +216,15 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Sets a breathing effect on the keyboard, fading
+        /// between randomly chosen colors.
+        /// </summary>
+        public void SetBreathing()
+        {
+            SetBreathing(new Breathing(BreathingType.Random, Color.Black, Color.Black));
+        }
+
+        /// <summary>
         /// Sets a reactive effect on the keyboard with the specified
         /// color and duration.
         /// </summary>

--- a/Corale.Colore/Razer/Keyboard/Effects/Breathing.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Breathing.cs
@@ -44,7 +44,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         /// <summary>
         /// The type of breathing effect.
         /// </summary>
-        [UsedImplicitly]
+        [PublicAPI]
         public readonly BreathingType Type;
 
         /// <summary>

--- a/Corale.Colore/Razer/Keyboard/Effects/BreathingType.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/BreathingType.cs
@@ -1,6 +1,6 @@
-// ---------------------------------------------------------------------------------------
-// <copyright file="Breathing.cs" company="Corale">
-//     Copyright � 2015 by Adam Hellberg and Brandon Scott.
+﻿// ---------------------------------------------------------------------------------------
+// <copyright file="BreathingType.cs" company="Corale">
+//     Copyright © 2015 by Adam Hellberg and Brandon Scott.
 //
 //     Permission is hereby granted, free of charge, to any person obtaining a copy of
 //     this software and associated documentation files (the "Software"), to deal in
@@ -30,57 +30,29 @@
 
 namespace Corale.Colore.Razer.Keyboard.Effects
 {
-    using System.Runtime.InteropServices;
-
     using Corale.Colore.Annotations;
-    using Corale.Colore.Core;
 
     /// <summary>
-    /// Describes the breathing effect.
+    /// Supported breathing effect types for mouse pads.
     /// </summary>
-    [StructLayout(LayoutKind.Sequential)]
-    public struct Breathing
+    public enum BreathingType
     {
         /// <summary>
-        /// The type of breathing effect.
-        /// </summary>
-        [UsedImplicitly]
-        public readonly BreathingType Type;
-
-        /// <summary>
-        /// First color.
+        /// Breathes between two specified colors.
         /// </summary>
         [PublicAPI]
-        public readonly Color First;
+        Two = 1,
 
         /// <summary>
-        /// Second color.
+        /// Breathes between two random colors.
         /// </summary>
         [PublicAPI]
-        public readonly Color Second;
+        Random,
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Breathing" /> struct.
+        /// Invalid type.
         /// </summary>
-        /// <param name="type">The type of breathing effect.</param>
-        /// <param name="first">Initial color.</param>
-        /// <param name="second">Second color.</param>
-        public Breathing(BreathingType type, Color first, Color second)
-        {
-            Type = type;
-            First = first;
-            Second = second;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Breathing" /> struct with
-        /// two colors to breathe between.
-        /// </summary>
-        /// <param name="first">Initial color.</param>
-        /// <param name="second">Second color.</param>
-        public Breathing(Color first, Color second)
-            : this(BreathingType.Two, first, second)
-        {
-        }
+        [PublicAPI]
+        Invalid
     }
 }


### PR DESCRIPTION
Latest Versions of the SDK added a BreathingType to the Keyboard Breathing effect causing the current implementation to not work anymore. This fixes the Breathing Effect by adding a BreathingType to the struct.

SDK 1.1.2
``` C++
        // Chroma keyboard effects
        //! Breathing effect type
        typedef struct BREATHING_EFFECT_TYPE
        {
            //! Breathing effects.
            enum Type
            {
                TWO_COLORS = 1,     //!< 2 colors
                RANDOM_COLORS,      //!< Random colors
                INVALID
            } Type;
            COLORREF Color1;    //!< First color.
            COLORREF Color2;    //!< Second color.
        } BREATHING_EFFECT_TYPE;
```