### PR TITLE
Integrate coveralls in build process

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="coveralls.io" version="1.2.2" />
-  <package id="NUnit.Runners" version="2.6.4" />
-  <package id="OpenCover" version="4.5.3723" />
-</packages>

--- a/Corale.Colore.Tests/packages.config
+++ b/Corale.Colore.Tests/packages.config
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="coveralls.net" version="0.6.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
   <package id="NUnit" version="3.0.1" targetFramework="net45" />
+  <package id="NUnit.Console" version="3.0.1" targetFramework="net45" />
+  <package id="NUnit.Runners" version="3.0.1" targetFramework="net45" />
+  <package id="OpenCover" version="4.6.166" targetFramework="net45" />
 </packages>

--- a/Corale.Colore.sln
+++ b/Corale.Colore.sln
@@ -7,11 +7,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Corale.Colore", "Corale.Col
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Corale.Colore.Tests", "Corale.Colore.Tests\Corale.Colore.Tests.csproj", "{54CE955B-DE44-43CE-830D-13D30BB2FB02}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{0D7AD1CD-C34D-473C-BDED-4B7E6F5B6906}"
-	ProjectSection(SolutionItems) = preProject
-		.nuget\packages.config = .nuget\packages.config
-	EndProjectSection
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/report_coverage.ps1
+++ b/report_coverage.ps1
@@ -32,6 +32,14 @@ $Env:GIT_EMAIL = $git_info[2]
 $Env:GIT_SUBJECT = $git_info[3]
 $Env:GIT_BRANCH = git --% name-rev --name-only HEAD
 
+If ($Env:GIT_BRANCH -eq "undefined")
+{
+    # If the branch is undefined we are most likely building a PR
+    # and the coveralls tool does not yet support sending PR
+    # data to coveralls properly
+    Exit
+}
+
 .\packages\OpenCover.4.6.166\tools\OpenCover.Console.exe --% -register "-filter:%OPENCOVER_FILTER%" "-target:%NUNIT_EXEC%" "-targetargs:%TARGET_ARGS%" "-targetdir:%TARGET_DIR%" -output:coverage.xml
 
 .\packages\coveralls.net.0.6.0\tools\csmacnz.Coveralls.exe --% --opencover -i coverage.xml --useRelativePaths --repoTokenVariable COVERALLS_REPO_TOKEN --jobId %CI_JOB_ID% --serviceName TeamCity --commitId "%GIT_HASH%" --commitBranch "%GIT_BRANCH%" --commitAuthor "%GIT_NAME%" --commitEmail "%GIT_EMAIL%" --commitMessage "%GIT_SUBJECT%"

--- a/report_coverage.ps1
+++ b/report_coverage.ps1
@@ -13,13 +13,13 @@ If ($Platform -ne "Any CPU")
 }
 
 $dll = "Corale.Colore.Tests\bin\$Configuration\Corale.Colore.Tests.dll"
-$nunit = "packages\NUnit.Runners.2.6.4\tools\nunit-console.exe"
+$nunit = "packages\NUnit.Console.3.0.1\tools\nunit3-console.exe"
 $filter = "+[Corale.Colore*]* -[*Tests]* -[*]*Constants -[*]Corale.Colore.Native* -[*]*NativeMethods -[*]*NativeWrapper -[*]Corale.Colore.Annotations*"
-$targetArgs = "/noshadow /domain:single $dll"
+$targetArgs = "$dll"
 
 $Env:NUNIT_EXEC = $nunit
 $Env:OPENCOVER_FILTER = $filter
 $Env:TARGET_ARGS = $targetArgs
 
-.\packages\OpenCover.4.5.3723\OpenCover.Console.exe --% -register:user -filter:"%OPENCOVER_FILTER%" -target:"%NUNIT_EXEC%" -targetargs:"%TARGET_ARGS%" -output:coverage.xml
-.\packages\coveralls.io.1.2.2\tools\coveralls.net.exe --opencover coverage.xml
+.\packages\OpenCover.4.6.166\tools\OpenCover.Console.exe --% -register:user -filter:"%OPENCOVER_FILTER%" -target:"%NUNIT_EXEC%" -targetargs:"%TARGET_ARGS%" -output:coverage.xml
+.\packages\coveralls.net.0.6.0\tools\csmacnz.Coveralls.exe --% --opencover -i coverage.xml --repoTokenVariable COVERALLS_REPO_TOKEN --jobId %CI_JOB_ID% --serviceName TeamCity

--- a/report_coverage.ps1
+++ b/report_coverage.ps1
@@ -34,4 +34,4 @@ $Env:GIT_BRANCH = git --% name-rev --name-only HEAD
 
 .\packages\OpenCover.4.6.166\tools\OpenCover.Console.exe --% -register "-filter:%OPENCOVER_FILTER%" "-target:%NUNIT_EXEC%" "-targetargs:%TARGET_ARGS%" "-targetdir:%TARGET_DIR%" -output:coverage.xml
 
-.\packages\coveralls.net.0.6.0\tools\csmacnz.Coveralls.exe --% --opencover -i coverage.xml --useRelativePaths --repoTokenVariable COVERALLS_REPO_TOKEN --jobId %CI_JOB_ID% --serviceName TeamCity --commitId %GIT_HASH% --commitBranch %GIT_BRANCH% --commitAuthor %GIT_NAME% --commitEmail %GIT_EMAIL% --commitMessage %GIT_SUBJECT%
+.\packages\coveralls.net.0.6.0\tools\csmacnz.Coveralls.exe --% --opencover -i coverage.xml --useRelativePaths --repoTokenVariable COVERALLS_REPO_TOKEN --jobId %CI_JOB_ID% --serviceName TeamCity --commitId "%GIT_HASH%" --commitBranch "%GIT_BRANCH%" --commitAuthor "%GIT_NAME%" --commitEmail "%GIT_EMAIL%" --commitMessage "%GIT_SUBJECT%"

--- a/report_coverage.ps1
+++ b/report_coverage.ps1
@@ -33,4 +33,6 @@ $Env:GIT_SUBJECT = $git_info[3]
 $Env:GIT_BRANCH = git --% name-rev --name-only HEAD
 
 .\packages\OpenCover.4.6.166\tools\OpenCover.Console.exe --% -register "-filter:%OPENCOVER_FILTER%" "-target:%NUNIT_EXEC%" "-targetargs:%TARGET_ARGS%" "-targetdir:%TARGET_DIR%" -output:coverage.xml
-.\packages\coveralls.net.0.6.0\tools\csmacnz.Coveralls.exe --% --opencover -i coverage.xml --useRelativePaths --repoTokenVariable COVERALLS_REPO_TOKEN --jobId %CI_JOB_ID% --serviceName TeamCity --commitId %GIT_HASH% --commitBranch %GIT_BRANCH% --commitAuthor %GIT_NAME% --commitEmail %GIT_EMAIL% --commitMessage %GIT_SUBJECT%
+
+# --commitId %GIT_HASH% --commitBranch %GIT_BRANCH% --commitAuthor %GIT_NAME% --commitEmail %GIT_EMAIL% --commitMessage %GIT_SUBJECT%
+.\packages\coveralls.net.0.6.0\tools\csmacnz.Coveralls.exe --% --opencover -i coverage.xml --useRelativePaths --repoTokenVariable COVERALLS_REPO_TOKEN --jobId %CI_JOB_ID% --serviceName TeamCity

--- a/report_coverage.ps1
+++ b/report_coverage.ps1
@@ -12,14 +12,25 @@ If ($Platform -ne "Any CPU")
     Exit
 }
 
-$dll = "Corale.Colore.Tests\bin\$Configuration\Corale.Colore.Tests.dll"
+$dir = "Corale.Colore.Tests\bin\$Configuration"
+$dll = "$dir\Corale.Colore.Tests.dll"
 $nunit = "packages\NUnit.Console.3.0.1\tools\nunit3-console.exe"
 $filter = "+[Corale.Colore*]* -[*Tests]* -[*]*Constants -[*]Corale.Colore.Native* -[*]*NativeMethods -[*]*NativeWrapper -[*]Corale.Colore.Annotations*"
 $targetArgs = "$dll"
 
 $Env:NUNIT_EXEC = $nunit
 $Env:OPENCOVER_FILTER = $filter
+$Env:TARGET_DIR = $dir
 $Env:TARGET_ARGS = $targetArgs
 
-.\packages\OpenCover.4.6.166\tools\OpenCover.Console.exe --% -register:user -filter:"%OPENCOVER_FILTER%" -target:"%NUNIT_EXEC%" -targetargs:"%TARGET_ARGS%" -output:coverage.xml
-.\packages\coveralls.net.0.6.0\tools\csmacnz.Coveralls.exe --% --opencover -i coverage.xml --repoTokenVariable COVERALLS_REPO_TOKEN --jobId %CI_JOB_ID% --serviceName TeamCity
+$git_log = git --% log -1 --format=%H;%an;%ae;%s
+$git_info = $git_log -split ';'
+
+$Env:GIT_HASH = $git_info[0]
+$Env:GIT_NAME = $git_info[1]
+$Env:GIT_EMAIL = $git_info[2]
+$Env:GIT_SUBJECT = $git_info[3]
+$Env:GIT_BRANCH = git --% name-rev --name-only HEAD
+
+.\packages\OpenCover.4.6.166\tools\OpenCover.Console.exe --% -register "-filter:%OPENCOVER_FILTER%" "-target:%NUNIT_EXEC%" "-targetargs:%TARGET_ARGS%" "-targetdir:%TARGET_DIR%" -output:coverage.xml
+.\packages\coveralls.net.0.6.0\tools\csmacnz.Coveralls.exe --% --opencover -i coverage.xml --useRelativePaths --repoTokenVariable COVERALLS_REPO_TOKEN --jobId %CI_JOB_ID% --serviceName TeamCity --commitId %GIT_HASH% --commitBranch %GIT_BRANCH% --commitAuthor %GIT_NAME% --commitEmail %GIT_EMAIL% --commitMessage %GIT_SUBJECT%

--- a/report_coverage.ps1
+++ b/report_coverage.ps1
@@ -34,5 +34,4 @@ $Env:GIT_BRANCH = git --% name-rev --name-only HEAD
 
 .\packages\OpenCover.4.6.166\tools\OpenCover.Console.exe --% -register "-filter:%OPENCOVER_FILTER%" "-target:%NUNIT_EXEC%" "-targetargs:%TARGET_ARGS%" "-targetdir:%TARGET_DIR%" -output:coverage.xml
 
-# --commitId %GIT_HASH% --commitBranch %GIT_BRANCH% --commitAuthor %GIT_NAME% --commitEmail %GIT_EMAIL% --commitMessage %GIT_SUBJECT%
-.\packages\coveralls.net.0.6.0\tools\csmacnz.Coveralls.exe --% --opencover -i coverage.xml --useRelativePaths --repoTokenVariable COVERALLS_REPO_TOKEN --jobId %CI_JOB_ID% --serviceName TeamCity
+.\packages\coveralls.net.0.6.0\tools\csmacnz.Coveralls.exe --% --opencover -i coverage.xml --useRelativePaths --repoTokenVariable COVERALLS_REPO_TOKEN --jobId %CI_JOB_ID% --serviceName TeamCity --commitId %GIT_HASH% --commitBranch %GIT_BRANCH% --commitAuthor %GIT_NAME% --commitEmail %GIT_EMAIL% --commitMessage %GIT_SUBJECT%

--- a/report_coverage.ps1
+++ b/report_coverage.ps1
@@ -13,7 +13,7 @@ If ($Platform -ne "Any CPU")
 }
 
 $dir = "Corale.Colore.Tests\bin\$Configuration"
-$dll = "$dir\Corale.Colore.Tests.dll"
+$dll = "Corale.Colore.Tests.dll"
 $nunit = "packages\NUnit.Console.3.0.1\tools\nunit3-console.exe"
 $filter = "+[Corale.Colore*]* -[*Tests]* -[*]*Constants -[*]Corale.Colore.Native* -[*]*NativeMethods -[*]*NativeWrapper -[*]Corale.Colore.Annotations*"
 $targetArgs = "$dll"


### PR DESCRIPTION
This PR updates the coverage script to get coveralls back into the build process.

Working coveralls run on [TeamCity](http://tc.coralestudios.com/viewLog.html?buildId=918&tab=buildResultsDiv&buildTypeId=colore_mainbuild) and [coveralls](https://coveralls.io/builds/4523241).

This PR also removes the unit test/coverage packages that were installed on solution level previously (NuGet 3.0+ no longer supports that feature) and installs updated packages to the unit test project instead.

This closes issue #74.

Edit: It should be noted that until this PR is merged any other builds on TeamCity **will be broken** because TeamCity now expects the changes in this PR to be present.