### PR TITLE
Alter Keypad SetReactive for consistency

### DIFF
--- a/Corale.Colore/Core/IKeypad.cs
+++ b/Corale.Colore/Core/IKeypad.cs
@@ -94,10 +94,10 @@ namespace Corale.Colore.Core
         /// Sets a <see cref="Reactive" /> effect on the keypad
         /// with the specified parameters.
         /// </summary>
-        /// <param name="duration">Duration of the effect.</param>
         /// <param name="color">Color of the effect.</param>
+        /// <param name="duration">Duration of the effect.</param>
         [PublicAPI]
-        void SetReactive(Duration duration, Color color);
+        void SetReactive(Color color, Duration duration);
 
         /// <summary>
         /// Sets a <see cref="Static" /> effect on the keypad.

--- a/Corale.Colore/Core/Keypad.cs
+++ b/Corale.Colore/Core/Keypad.cs
@@ -186,11 +186,11 @@ namespace Corale.Colore.Core
         /// Sets a <see cref="Reactive" /> effect on the keypad
         /// with the specified parameters.
         /// </summary>
-        /// <param name="duration">Duration of the effect.</param>
         /// <param name="color">Color of the effect.</param>
-        public void SetReactive(Duration duration, Color color)
+        /// <param name="duration">Duration of the effect.</param>
+        public void SetReactive(Color color, Duration duration)
         {
-            SetReactive(new Reactive(duration, color));
+            SetReactive(new Reactive(color, duration));
         }
 
         /// <summary>

--- a/Corale.Colore/Razer/Keypad/Effects/Reactive.cs
+++ b/Corale.Colore/Razer/Keypad/Effects/Reactive.cs
@@ -51,12 +51,12 @@ namespace Corale.Colore.Razer.Keypad.Effects
         /// <summary>
         /// Initializes a new instance of the <see cref="Reactive" /> struct.
         /// </summary>
-        /// <param name="duration">Duration of the effect.</param>
         /// <param name="color">Color of the effect.</param>
-        public Reactive(Duration duration, Color color)
+        /// <param name="duration">Duration of the effect.</param>
+        public Reactive(Color color, Duration duration)
         {
-            Duration = duration;
             Color = color;
+            Duration = duration;
         }
     }
 }


### PR DESCRIPTION
Changes `Keypad` SetReactive method so the (Color, Duration) overload is consistent.

Fix #134.