### PR TITLE
Add a Logo entry to the keyboard key enum

### DIFF
--- a/Corale.Colore/Razer/Keyboard/Key.cs
+++ b/Corale.Colore/Razer/Keyboard/Key.cs
@@ -33,6 +33,12 @@ namespace Corale.Colore.Razer.Keyboard
     public enum Key
     {
         /// <summary>
+        /// The Razer logo on the keyboard.
+        /// </summary>
+        [PublicAPI]
+        Logo = 0x0014,
+
+        /// <summary>
         /// Esc key.
         /// </summary>
         [PublicAPI]


### PR DESCRIPTION
This let's users of Colore access the Logo LED on the keyboard without needing to use the index manually (0, 20).

It's put in the Key enum despite being an LED since it's still part of the keyboard as an enum with a single member doesn't make much sense.

Implements #151.