### PR TITLE
Use one-dimensional arrays for custom grid effects

### DIFF
--- a/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
+++ b/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
@@ -163,7 +163,7 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
         }
 
         [Test]
-        public void ShouldThrowWhenInvalidRowCount()
+        public void ShouldThrowWhenInvalid2DRowCount()
         {
             // We don't need to set up the columns as the code should throw before
             // it reaches the point of iterating rows
@@ -178,13 +178,26 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
         }
 
         [Test]
-        public void ShouldThrowWhenInvalidColumnCount()
+        public void ShouldThrowWhenInvalid2DColumnCount()
         {
             var arr = new Color[Constants.MaxRows][];
 
             // We only need to populate one of the rows, as the
             // code shouldn't check further anyway.
             arr[0] = new Color[2];
+
+            // ReSharper disable once NotAccessedVariable
+            Custom dummy;
+
+            Assert.That(
+                () => dummy = new Custom(arr),
+                Throws.ArgumentException.With.Property("ParamName").EqualTo("colors"));
+        }
+
+        [Test]
+        public void ShouldThrowWhenInvalid1DSize()
+        {
+            var arr = new Color[2];
 
             // ReSharper disable once NotAccessedVariable
             Custom dummy;

--- a/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
+++ b/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
@@ -320,7 +320,8 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
 
             Assert.False(grid == null);
             Assert.True(grid != null);
-            Assert.False(grid.Equals(null));
+            Assert.False(grid.Equals((Color[][])null));
+            Assert.False(grid.Equals((Color[])null));
             Assert.AreNotEqual(grid, null);
         }
 

--- a/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
+++ b/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
@@ -37,7 +37,7 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
     public class CustomTests
     {
         [Test]
-        public void ShouldThrowWhenOutOfRangeGet()
+        public void ShouldThrowWhenOutOfRange2DGet()
         {
             var grid = Custom.Create();
 
@@ -78,7 +78,7 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
         }
 
         [Test]
-        public void ShouldThrowWhenOutOfRangeSet()
+        public void ShouldThrowWhenOutOfRange2DSet()
         {
             var grid = Custom.Create();
 
@@ -113,6 +113,53 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
                       .EqualTo("column")
                       .And.Property("ActualValue")
                       .EqualTo(Constants.MaxColumns));
+        }
+
+        [Test]
+        public void ShouldThrowWhenOutOfRange1DGet()
+        {
+            var grid = Custom.Create();
+
+            // ReSharper disable once NotAccessedVariable
+            Color dummy;
+
+            Assert.That(
+                () => dummy = grid[-1],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                    .With.Property("ParamName")
+                    .EqualTo("index")
+                    .And.Property("ActualValue")
+                    .EqualTo(-1));
+
+            Assert.That(
+                () => dummy = grid[Constants.MaxKeys],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                    .With.Property("ParamName")
+                    .EqualTo("index")
+                    .And.Property("ActualValue")
+                    .EqualTo(Constants.MaxKeys));
+        }
+
+        [Test]
+        public void ShouldThrowWhenOutOfRange1DSet()
+        {
+            var grid = Custom.Create();
+
+            Assert.That(
+                () => grid[-1] = Color.Red,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                    .With.Property("ParamName")
+                    .EqualTo("index")
+                    .And.Property("ActualValue")
+                    .EqualTo(-1));
+
+            Assert.That(
+                () => grid[Constants.MaxKeys] = Color.Red,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                    .With.Property("ParamName")
+                    .EqualTo("index")
+                    .And.Property("ActualValue")
+                    .EqualTo(Constants.MaxKeys));
         }
 
         [Test]
@@ -172,7 +219,7 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
         }
 
         [Test]
-        public void ShouldSetProperColorsWithArrCtor()
+        public void ShouldSetProperColorsWith2DCtor()
         {
             var arr = new Color[Constants.MaxRows][];
 
@@ -191,6 +238,21 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
                 for (var col = 0; col < Constants.MaxColumns; col++)
                     Assert.That(grid[row, col], Is.EqualTo(arr[row][col]));
             }
+        }
+
+        [Test]
+        public void ShouldSetProperColorsWith1DCtor()
+        {
+            var arr = new Color[Constants.MaxKeys];
+
+            arr[5] = Color.Pink;
+            arr[10] = Color.Red;
+            arr[25] = Color.Blue;
+
+            var grid = new Custom(arr);
+
+            for (var index = 0; index < Constants.MaxKeys; index++)
+                Assert.That(grid[index], Is.EqualTo(arr[index]));
         }
 
         [Test]
@@ -237,7 +299,7 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
         }
 
         [Test]
-        public void ShouldEqualIdenticalArray()
+        public void ShouldEqualIdentical2DArray()
         {
             var grid = new Custom(Color.Red);
             var arr = new Color[Constants.MaxRows][];
@@ -257,7 +319,7 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
         }
 
         [Test]
-        public void ShouldNotEqualDifferentArray()
+        public void ShouldNotEqualDifferent2DArray()
         {
             var grid = new Custom(Color.Pink);
             var arr = new Color[Constants.MaxRows][];
@@ -277,7 +339,7 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
         }
 
         [Test]
-        public void ShouldNotEqualArrayWithInvalidRowCount()
+        public void ShouldNotEqual2DArrayWithInvalidRowCount()
         {
             var grid = Custom.Create();
             var arr = new Color[2][];
@@ -289,11 +351,54 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
         }
 
         [Test]
-        public void ShouldNotEqualArrayWithInvalidColumnCount()
+        public void ShouldNotEqual2DArrayWithInvalidColumnCount()
         {
             var grid = Custom.Create();
             var arr = new Color[Constants.MaxRows][];
             arr[0] = new Color[2];
+
+            Assert.False(grid == arr);
+            Assert.True(grid != arr);
+            Assert.False(grid.Equals(arr));
+            Assert.AreNotEqual(grid, arr);
+        }
+
+        [Test]
+        public void ShouldEqualIdentical1DArray()
+        {
+            var grid = new Custom(Color.Red);
+            var arr = new Color[Constants.MaxKeys];
+
+            // Populate the 1D array
+            for (var index = 0; index < Constants.MaxKeys; index++)
+                arr[index] = Color.Red;
+
+            Assert.True(grid == arr);
+            Assert.False(grid != arr);
+            Assert.True(grid.Equals(arr));
+            Assert.AreEqual(grid, arr);
+        }
+
+        [Test]
+        public void ShouldNotEqualDifferent1DArray()
+        {
+            var grid = new Custom(Color.Pink);
+            var arr = new Color[Constants.MaxKeys];
+
+            for (var index = 0; index < Constants.MaxKeys; index++)
+                arr[index] = Color.Red;
+
+            Assert.False(grid == arr);
+            Assert.True(grid != arr);
+            Assert.False(grid.Equals(arr));
+            Assert.AreNotEqual(grid, arr);
+        }
+
+        [Test]
+        public void ShouldNotEqual1DArrayWithInvalidSize()
+        {
+            var grid = Custom.Create();
+            var arr = new Color[2];
 
             Assert.False(grid == arr);
             Assert.True(grid != arr);
@@ -326,10 +431,17 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
         }
 
         [Test]
-        public void ShouldGetWithIndexIndexer()
+        public void ShouldGetWithGridIndexer()
         {
             var grid = new Custom(Color.Red);
             Assert.AreEqual(Color.Red, grid[3, 3]);
+        }
+
+        [Test]
+        public void ShouldGetWithIndexIndexer()
+        {
+            var grid = new Custom(Color.Red);
+            Assert.AreEqual(Color.Red, grid[3]);
         }
 
         [Test]
@@ -340,13 +452,23 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
         }
 
         [Test]
-        public void ShouldSetWithIndexIndexer()
+        public void ShouldSetWithGridIndexer()
         {
             var grid = Custom.Create();
 
             grid[5, 5] = Color.Red;
 
             Assert.AreEqual(Color.Red, grid[5, 5]);
+        }
+
+        [Test]
+        public void ShouldSetWithIndexIndexer()
+        {
+            var grid = Custom.Create();
+
+            grid[5] = Color.Red;
+
+            Assert.AreEqual(Color.Red, grid[5]);
         }
 
         [Test]

--- a/Corale.Colore.Tests/Razer/Keypad/Effects/CustomTests.cs
+++ b/Corale.Colore.Tests/Razer/Keypad/Effects/CustomTests.cs
@@ -35,7 +35,7 @@ namespace Corale.Colore.Tests.Razer.Keypad.Effects
     public class CustomTests
     {
         [Test]
-        public void ShouldThrowWhenOutOfRangeGet()
+        public void ShouldThrowWhenOutOfRange2DGet()
         {
             var grid = Custom.Create();
 
@@ -76,7 +76,7 @@ namespace Corale.Colore.Tests.Razer.Keypad.Effects
         }
 
         [Test]
-        public void ShouldThrowWhenOutOfRangeSet()
+        public void ShouldThrowWhenOutOfRange2DSet()
         {
             var grid = Custom.Create();
 
@@ -114,7 +114,54 @@ namespace Corale.Colore.Tests.Razer.Keypad.Effects
         }
 
         [Test]
-        public void ShouldThrowWhenInvalidRowCount()
+        public void ShouldThrowWhenOutOfRange1DGet()
+        {
+            var grid = Custom.Create();
+
+            // ReSharper disable once NotAccessedVariable
+            Color dummy;
+
+            Assert.That(
+                () => dummy = grid[-1],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                    .With.Property("ParamName")
+                    .EqualTo("index")
+                    .And.Property("ActualValue")
+                    .EqualTo(-1));
+
+            Assert.That(
+                () => dummy = grid[Constants.MaxKeys],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                    .With.Property("ParamName")
+                    .EqualTo("index")
+                    .And.Property("ActualValue")
+                    .EqualTo(Constants.MaxKeys));
+        }
+
+        [Test]
+        public void ShouldThrowWhenOutOfRange1DSet()
+        {
+            var grid = Custom.Create();
+
+            Assert.That(
+                () => grid[-1] = Color.Red,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                    .With.Property("ParamName")
+                    .EqualTo("index")
+                    .And.Property("ActualValue")
+                    .EqualTo(-1));
+
+            Assert.That(
+                () => grid[Constants.MaxKeys] = Color.Red,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                    .With.Property("ParamName")
+                    .EqualTo("index")
+                    .And.Property("ActualValue")
+                    .EqualTo(Constants.MaxKeys));
+        }
+
+        [Test]
+        public void ShouldThrowWhenInvalid2DRowCount()
         {
             // We don't need to set up the columns as the code should throw before
             // it reaches the point of iterating rows
@@ -129,13 +176,26 @@ namespace Corale.Colore.Tests.Razer.Keypad.Effects
         }
 
         [Test]
-        public void ShouldThrowWhenInvalidColumnCount()
+        public void ShouldThrowWhenInvalid2DColumnCount()
         {
             var arr = new Color[Constants.MaxRows][];
 
             // We only need to populate one of the rows, as the
             // code shouldn't check further anyway.
             arr[0] = new Color[2];
+
+            // ReSharper disable once NotAccessedVariable
+            Custom dummy;
+
+            Assert.That(
+                () => dummy = new Custom(arr),
+                Throws.ArgumentException.With.Property("ParamName").EqualTo("colors"));
+        }
+
+        [Test]
+        public void ShouldThrowWhenInvalid1DSize()
+        {
+            var arr = new Color[2];
 
             // ReSharper disable once NotAccessedVariable
             Custom dummy;
@@ -170,7 +230,7 @@ namespace Corale.Colore.Tests.Razer.Keypad.Effects
         }
 
         [Test]
-        public void ShouldSetProperColorsWithArrCtor()
+        public void ShouldSetProperColorsWith2DCtor()
         {
             var arr = new Color[Constants.MaxRows][];
 
@@ -189,6 +249,21 @@ namespace Corale.Colore.Tests.Razer.Keypad.Effects
                 for (var col = 0; col < Constants.MaxColumns; col++)
                     Assert.That(grid[row, col], Is.EqualTo(arr[row][col]));
             }
+        }
+
+        [Test]
+        public void ShouldSetProperColorsWith1DCtor()
+        {
+            var arr = new Color[Constants.MaxKeys];
+
+            arr[2] = Color.Pink;
+            arr[4] = Color.Red;
+            arr[8] = Color.Blue;
+
+            var grid = new Custom(arr);
+
+            for (var index = 0; index < Constants.MaxKeys; index++)
+                Assert.That(grid[index], Is.EqualTo(arr[index]));
         }
 
         [Test]
@@ -248,7 +323,7 @@ namespace Corale.Colore.Tests.Razer.Keypad.Effects
         }
 
         [Test]
-        public void ShouldEqualIdenticalArray()
+        public void ShouldEqualIdentical2DArray()
         {
             var grid = new Custom(Color.Red);
             var arr = new Color[Constants.MaxRows][];
@@ -268,7 +343,7 @@ namespace Corale.Colore.Tests.Razer.Keypad.Effects
         }
 
         [Test]
-        public void ShouldNotEqualDifferentArray()
+        public void ShouldNotEqualDifferent2DArray()
         {
             var grid = new Custom(Color.Pink);
             var arr = new Color[Constants.MaxRows][];
@@ -288,7 +363,7 @@ namespace Corale.Colore.Tests.Razer.Keypad.Effects
         }
 
         [Test]
-        public void ShouldNotEqualArrayWithInvalidRowCount()
+        public void ShouldNotEqual2DArrayWithInvalidRowCount()
         {
             var grid = Custom.Create();
             var arr = new Color[2][];
@@ -300,11 +375,54 @@ namespace Corale.Colore.Tests.Razer.Keypad.Effects
         }
 
         [Test]
-        public void ShouldNotEqualArrayWithInvalidColumnCount()
+        public void ShouldNotEqual2DArrayWithInvalidColumnCount()
         {
             var grid = Custom.Create();
             var arr = new Color[Constants.MaxRows][];
             arr[0] = new Color[2];
+
+            Assert.False(grid == arr);
+            Assert.True(grid != arr);
+            Assert.False(grid.Equals(arr));
+            Assert.AreNotEqual(grid, arr);
+        }
+
+        [Test]
+        public void ShouldEqualIdentical1DArray()
+        {
+            var grid = new Custom(Color.Red);
+            var arr = new Color[Constants.MaxKeys];
+
+            // Populate the 1D array
+            for (var index = 0; index < Constants.MaxKeys; index++)
+                arr[index] = Color.Red;
+
+            Assert.True(grid == arr);
+            Assert.False(grid != arr);
+            Assert.True(grid.Equals(arr));
+            Assert.AreEqual(grid, arr);
+        }
+
+        [Test]
+        public void ShouldNotEqualDifferent1DArray()
+        {
+            var grid = new Custom(Color.Pink);
+            var arr = new Color[Constants.MaxKeys];
+
+            for (var index = 0; index < Constants.MaxKeys; index++)
+                arr[index] = Color.Red;
+
+            Assert.False(grid == arr);
+            Assert.True(grid != arr);
+            Assert.False(grid.Equals(arr));
+            Assert.AreNotEqual(grid, arr);
+        }
+
+        [Test]
+        public void ShouldNotEqual1DArrayWithInvalidSize()
+        {
+            var grid = Custom.Create();
+            var arr = new Color[2];
 
             Assert.False(grid == arr);
             Assert.True(grid != arr);
@@ -331,15 +449,33 @@ namespace Corale.Colore.Tests.Razer.Keypad.Effects
 
             Assert.False(grid == null);
             Assert.True(grid != null);
-            Assert.False(grid.Equals(null));
+            Assert.False(grid.Equals((Color[][])null));
+            Assert.False(grid.Equals((Color[])null));
             Assert.AreNotEqual(grid, null);
+        }
+
+        [Test]
+        public void ShouldGetWithGridIndexer()
+        {
+            var grid = new Custom(Color.Red);
+            Assert.AreEqual(Color.Red, grid[3, 3]);
         }
 
         [Test]
         public void ShouldGetWithIndexIndexer()
         {
             var grid = new Custom(Color.Red);
-            Assert.AreEqual(Color.Red, grid[3, 3]);
+            Assert.AreEqual(Color.Red, grid[3]);
+        }
+
+        [Test]
+        public void ShouldSetWithGridIndexer()
+        {
+            var grid = Custom.Create();
+
+            grid[3, 4] = Color.Red;
+
+            Assert.AreEqual(Color.Red, grid[3, 4]);
         }
 
         [Test]
@@ -347,9 +483,9 @@ namespace Corale.Colore.Tests.Razer.Keypad.Effects
         {
             var grid = Custom.Create();
 
-            grid[3, 4] = Color.Red;
+            grid[5] = Color.Red;
 
-            Assert.AreEqual(Color.Red, grid[3, 4]);
+            Assert.AreEqual(Color.Red, grid[5]);
         }
     }
 }

--- a/Corale.Colore.Tests/Razer/Mouse/Effects/CustomGridTests.cs
+++ b/Corale.Colore.Tests/Razer/Mouse/Effects/CustomGridTests.cs
@@ -35,7 +35,7 @@ namespace Corale.Colore.Tests.Razer.Mouse.Effects
     public class CustomGridTests
     {
         [Test]
-        public void ShouldThrowWhenConstructedWithInvalidRowCount()
+        public void ShouldThrowWhenConstructedWithInvalid2DRowCount()
         {
             var colors = new Color[2][];
 
@@ -45,7 +45,7 @@ namespace Corale.Colore.Tests.Razer.Mouse.Effects
         }
 
         [Test]
-        public void ShouldThrowWhenConstructedWithInvalidColumnCount()
+        public void ShouldThrowWhenConstructedWithInvalid2DColumnCount()
         {
             var colors = new Color[Constants.MaxRows][];
             colors[0] = new Color[1];
@@ -77,6 +77,31 @@ namespace Corale.Colore.Tests.Razer.Mouse.Effects
         }
 
         [Test]
+        public void ShouldThrowWhenConstructedWithInvalid1DSize()
+        {
+            var colors = new Color[1];
+
+            Assert.That(
+                () => new CustomGrid(colors),
+                Throws.InstanceOf<ArgumentException>().With.Property("ParamName").EqualTo("colors"));
+        }
+
+        [Test]
+        public void ShouldConstructFrom1DArray()
+        {
+            var arr = new Color[Constants.MaxGridLeds];
+
+            arr[2] = Color.Pink;
+            arr[4] = Color.Red;
+            arr[8] = Color.Blue;
+
+            var grid = new CustomGrid(arr);
+
+            for (var index = 0; index < Constants.MaxGridLeds; index++)
+                Assert.That(grid[index], Is.EqualTo(arr[index]));
+        }
+
+        [Test]
         public void ShouldConstructFromColor()
         {
             var effect = new CustomGrid(Color.Red);
@@ -89,7 +114,7 @@ namespace Corale.Colore.Tests.Razer.Mouse.Effects
         }
 
         [Test]
-        public void ShouldThrowWhenOutOfRangeGet()
+        public void ShouldThrowWhenOutOfRange2DGet()
         {
             var effect = CustomGrid.Create();
 
@@ -130,7 +155,7 @@ namespace Corale.Colore.Tests.Razer.Mouse.Effects
         }
 
         [Test]
-        public void ShouldThrowWhenOutOfRangeSet()
+        public void ShouldThrowWhenOutOfRange2DSet()
         {
             var effect = CustomGrid.Create();
 
@@ -168,18 +193,80 @@ namespace Corale.Colore.Tests.Razer.Mouse.Effects
         }
 
         [Test]
-        public void ShouldGetCorrectColorWithIndexer()
+        public void ShouldThrowWhenOutOfRange1DGet()
+        {
+            var grid = CustomGrid.Create();
+
+            // ReSharper disable once NotAccessedVariable
+            Color dummy;
+
+            Assert.That(
+                () => dummy = grid[-1],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                    .With.Property("ParamName")
+                    .EqualTo("index")
+                    .And.Property("ActualValue")
+                    .EqualTo(-1));
+
+            Assert.That(
+                () => dummy = grid[Constants.MaxGridLeds],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                    .With.Property("ParamName")
+                    .EqualTo("index")
+                    .And.Property("ActualValue")
+                    .EqualTo(Constants.MaxGridLeds));
+        }
+
+        [Test]
+        public void ShouldThrowWhenOutOfRange1DSet()
+        {
+            var grid = CustomGrid.Create();
+
+            Assert.That(
+                () => grid[-1] = Color.Red,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                    .With.Property("ParamName")
+                    .EqualTo("index")
+                    .And.Property("ActualValue")
+                    .EqualTo(-1));
+
+            Assert.That(
+                () => grid[Constants.MaxGridLeds] = Color.Red,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                    .With.Property("ParamName")
+                    .EqualTo("index")
+                    .And.Property("ActualValue")
+                    .EqualTo(Constants.MaxGridLeds));
+        }
+
+        [Test]
+        public void ShouldGetCorrectColorWithGridIndexer()
         {
             Assert.AreEqual(Color.Red, new CustomGrid(Color.Red)[3, 3]);
         }
 
         [Test]
-        public void ShouldSetCorrectColorWithIndexer()
+        public void ShouldGetCorrectColorWithIndexIndexer()
+        {
+            Assert.AreEqual(Color.Red, new CustomGrid(Color.Red)[5]);
+        }
+
+        [Test]
+        public void ShouldSetCorrectColorWithGridIndexer()
         {
             var effect = CustomGrid.Create();
             effect[5, 5] = Color.Red;
 
             Assert.AreEqual(Color.Red, effect[5, 5]);
+        }
+
+        [Test]
+        public void ShouldSetCorrectColorWithIndexIndexer()
+        {
+            var effect = CustomGrid.Create();
+            effect[5] = Color.Red;
+
+            Assert.AreEqual(Color.Red, effect[5]);
         }
 
         [Test]
@@ -261,7 +348,7 @@ namespace Corale.Colore.Tests.Razer.Mouse.Effects
         }
 
         [Test]
-        public void ShouldEqualIdenticalArray()
+        public void ShouldEqualIdentical2DArray()
         {
             var effect = new CustomGrid(Color.Red);
 
@@ -282,7 +369,7 @@ namespace Corale.Colore.Tests.Razer.Mouse.Effects
         }
 
         [Test]
-        public void ShouldNotEqualDifferentArray()
+        public void ShouldNotEqualDifferent2DArray()
         {
             var effect = new CustomGrid(Color.Red);
 
@@ -303,7 +390,7 @@ namespace Corale.Colore.Tests.Razer.Mouse.Effects
         }
 
         [Test]
-        public void ShouldNotEqualArrayWithInvalidRowCount()
+        public void ShouldNotEqual2DArrayWithInvalidRowCount()
         {
             var effect = CustomGrid.Create();
 
@@ -316,7 +403,7 @@ namespace Corale.Colore.Tests.Razer.Mouse.Effects
         }
 
         [Test]
-        public void ShouldNotEqualArrayWithInvalidColumnCount()
+        public void ShouldNotEqual2DArrayWithInvalidColumnCount()
         {
             var effect = CustomGrid.Create();
 
@@ -327,6 +414,49 @@ namespace Corale.Colore.Tests.Razer.Mouse.Effects
             Assert.True(effect != array);
             Assert.False(effect.Equals(array));
             Assert.AreNotEqual(effect, array);
+        }
+
+        [Test]
+        public void ShouldEqualIdentical1DArray()
+        {
+            var grid = new CustomGrid(Color.Red);
+            var arr = new Color[Constants.MaxGridLeds];
+
+            // Populate the 1D array
+            for (var index = 0; index < Constants.MaxGridLeds; index++)
+                arr[index] = Color.Red;
+
+            Assert.True(grid == arr);
+            Assert.False(grid != arr);
+            Assert.True(grid.Equals(arr));
+            Assert.AreEqual(grid, arr);
+        }
+
+        [Test]
+        public void ShouldNotEqualDifferent1DArray()
+        {
+            var grid = new CustomGrid(Color.Pink);
+            var arr = new Color[Constants.MaxGridLeds];
+
+            for (var index = 0; index < Constants.MaxGridLeds; index++)
+                arr[index] = Color.Red;
+
+            Assert.False(grid == arr);
+            Assert.True(grid != arr);
+            Assert.False(grid.Equals(arr));
+            Assert.AreNotEqual(grid, arr);
+        }
+
+        [Test]
+        public void ShouldNotEqual1DArrayWithInvalidSize()
+        {
+            var grid = Custom.Create();
+            var arr = new Color[2];
+
+            Assert.False(grid == arr);
+            Assert.True(grid != arr);
+            Assert.False(grid.Equals(arr));
+            Assert.AreNotEqual(grid, arr);
         }
 
         [Test]
@@ -348,7 +478,8 @@ namespace Corale.Colore.Tests.Razer.Mouse.Effects
 
             Assert.False(effect == null);
             Assert.True(effect != null);
-            Assert.False(effect.Equals(null));
+            Assert.False(effect.Equals((Color[][])null));
+            Assert.False(effect.Equals((Color[])null));
             Assert.AreNotEqual(effect, null);
         }
     }

--- a/Corale.Colore.Tests/Razer/Mouse/Effects/CustomGridTests.cs
+++ b/Corale.Colore.Tests/Razer/Mouse/Effects/CustomGridTests.cs
@@ -450,7 +450,7 @@ namespace Corale.Colore.Tests.Razer.Mouse.Effects
         [Test]
         public void ShouldNotEqual1DArrayWithInvalidSize()
         {
-            var grid = Custom.Create();
+            var grid = CustomGrid.Create();
             var arr = new Color[2];
 
             Assert.False(grid == arr);

--- a/Corale.Colore.ruleset
+++ b/Corale.Colore.ruleset
@@ -69,6 +69,7 @@
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1127" Action="None" />
     <Rule Id="SA1309" Action="None" />
+    <Rule Id="SA1407" Action="Info" />
     <Rule Id="SA1503" Action="None" />
     <Rule Id="SA1520" Action="None" />
   </Rules>

--- a/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
@@ -68,6 +68,13 @@ namespace Corale.Colore.Razer.Keyboard.Effects
 
             for (var row = 0; row < Constants.MaxRows; row++)
             {
+                if (colors[row].Length != Constants.MaxColumns)
+                {
+                    throw new ArgumentException(
+                        $"Colors array has incorrect number of columns, should be {Constants.MaxColumns}, received {colors[row].Length} for row {row}.",
+                        nameof(colors));
+                }
+
                 for (var column = 0; column < Constants.MaxColumns; column++)
                     this[row, column] = colors[row][column];
             }
@@ -125,6 +132,14 @@ namespace Corale.Colore.Razer.Keyboard.Effects
                         "Attempted to access a row that does not exist.");
                 }
 
+                if (column < 0 || column >= Constants.MaxColumns)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(column),
+                        column,
+                        "Attempted to access a column that does not exist.");
+                }
+
 #pragma warning disable SA1407 // Arithmetic expressions must declare precedence
                 return _colors[column + row * Constants.MaxColumns];
 #pragma warning restore SA1407 // Arithmetic expressions must declare precedence
@@ -138,6 +153,14 @@ namespace Corale.Colore.Razer.Keyboard.Effects
                         nameof(row),
                         row,
                         "Attempted to access a row that does not exist.");
+                }
+
+                if (column < 0 || column >= Constants.MaxColumns)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(column),
+                        column,
+                        "Attempted to access a column that does not exist.");
                 }
 
 #pragma warning disable SA1407 // Arithmetic expressions must declare precedence
@@ -156,7 +179,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         {
             get
             {
-                if (index < 0 || index > Constants.MaxKeys)
+                if (index < 0 || index >= Constants.MaxKeys)
                 {
                     throw new ArgumentOutOfRangeException(
                         nameof(index),
@@ -280,8 +303,14 @@ namespace Corale.Colore.Razer.Keyboard.Effects
             if (obj is Custom)
                 return Equals((Custom)obj);
 
-            var arr = obj as Color[][];
-            return arr != null && Equals(arr);
+            var arr2D = obj as Color[][];
+
+            if (arr2D != null)
+                return Equals(arr2D);
+
+            var arr1D = obj as Color[];
+
+            return arr1D != null && Equals(arr1D);
         }
 
         /// <summary>

--- a/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
@@ -26,7 +26,6 @@
 namespace Corale.Colore.Razer.Keyboard.Effects
 {
     using System;
-    using System.Collections.Generic;
     using System.Runtime.InteropServices;
 
     using Corale.Colore.Annotations;
@@ -36,17 +35,18 @@ namespace Corale.Colore.Razer.Keyboard.Effects
     /// Describes a custom grid effect for every key.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public struct Custom : IEquatable<Custom>, IEquatable<Color[][]>
+    public struct Custom : IEquatable<Custom>, IEquatable<Color[][]>, IEquatable<Color[]>
     {
         /// <summary>
         /// Color definitions for each key on the keyboard.
         /// </summary>
         /// <remarks>
-        /// The array is 2-dimensional, with the first dimension
-        /// specifying the row for the key, and the second the column.
+        /// The array is 1-dimensional, but will be passed to code expecting
+        /// a 2-dimensional array. Access to this array is done using indices
+        /// according to: <c>column + row * Constants.MaxColumns</c>
         /// </remarks>
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.MaxRows)]
-        private readonly Row[] _rows;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.MaxKeys)]
+        private readonly Color[] _colors;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Custom" /> struct.
@@ -64,13 +64,33 @@ namespace Corale.Colore.Razer.Keyboard.Effects
                     nameof(colors));
             }
 
-            _rows = new Row[Constants.MaxRows];
+            _colors = new Color[Constants.MaxKeys];
 
-            for (uint row = 0; row < Constants.MaxRows; row++)
+            for (var row = 0; row < Constants.MaxRows; row++)
             {
-                var inRow = colors[row];
-                _rows[row] = new Row(inRow);
+                for (var column = 0; column < Constants.MaxColumns; column++)
+                    this[row, column] = colors[row][column];
             }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Custom" /> struct.
+        /// </summary>
+        /// <param name="colors">The colors to use.</param>
+        /// <exception cref="ArgumentException">Thrown if the colors array supplied is of an incorrect size.</exception>
+        public Custom(Color[] colors)
+        {
+            if (colors.Length != Constants.MaxKeys)
+            {
+                throw new ArgumentException(
+                    $"Colors array has incorrect size, should be {Constants.MaxKeys}, actual is {colors.Length}.",
+                    nameof(colors));
+            }
+
+            _colors = new Color[Constants.MaxKeys];
+
+            for (var index = 0; index < Constants.MaxKeys; index++)
+                this[index] = colors[index];
         }
 
         /// <summary>
@@ -80,10 +100,10 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         /// <param name="color">The <see cref="Color" /> to set each position to.</param>
         public Custom(Color color)
         {
-            _rows = new Row[Constants.MaxRows];
+            _colors = new Color[Constants.MaxKeys];
 
-            for (var row = 0; row < Constants.MaxRows; row++)
-                _rows[row] = new Row(color);
+            for (var index = 0; index < Constants.MaxKeys; index++)
+                this[index] = color;
         }
 
         /// <summary>
@@ -105,7 +125,9 @@ namespace Corale.Colore.Razer.Keyboard.Effects
                         "Attempted to access a row that does not exist.");
                 }
 
-                return _rows[row][column];
+#pragma warning disable SA1407 // Arithmetic expressions must declare precedence
+                return _colors[column + row * Constants.MaxColumns];
+#pragma warning restore SA1407 // Arithmetic expressions must declare precedence
             }
 
             set
@@ -118,7 +140,44 @@ namespace Corale.Colore.Razer.Keyboard.Effects
                         "Attempted to access a row that does not exist.");
                 }
 
-                _rows[row][column] = value;
+#pragma warning disable SA1407 // Arithmetic expressions must declare precedence
+                _colors[column + row * Constants.MaxColumns] = value;
+#pragma warning restore SA1407 // Arithmetic expressions must declare precedence
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a position in the custom grid.
+        /// </summary>
+        /// <param name="index">The index to access, zero indexed.</param>
+        /// <returns>The <see cref="Color" /> at the specified position.</returns>
+        [PublicAPI]
+        public Color this[int index]
+        {
+            get
+            {
+                if (index < 0 || index > Constants.MaxKeys)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(index),
+                        index,
+                        "Attempted to access an index that does not exist.");
+                }
+
+                return _colors[index];
+            }
+
+            set
+            {
+                if (index < 0 || index >= Constants.MaxKeys)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(index),
+                        index,
+                        "Attempted to access an index that does not exist.");
+                }
+
+                _colors[index] = value;
             }
         }
 
@@ -193,7 +252,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         /// <filterpriority>2</filterpriority>
         public override int GetHashCode()
         {
-            return _rows?.GetHashCode() ?? 0;
+            return _colors?.GetHashCode() ?? 0;
         }
 
         /// <summary>
@@ -279,125 +338,37 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         }
 
         /// <summary>
+        /// Indicates whether the current object is equal to an instance of
+        /// an array of <see cref="Color" />.
+        /// </summary>
+        /// <param name="other">An array of <see cref="Color" /> to compare with this object.</param>
+        /// <returns>
+        /// <c>true</c> if the <paramref name="other" /> object has the same
+        /// number of elements, and contain matching colors; otherwise, <c>false</c>.
+        /// </returns>
+        public bool Equals(Color[] other)
+        {
+            if (other == null || other.Length != Constants.MaxKeys)
+                return false;
+
+            for (var index = 0; index < Constants.MaxKeys; index++)
+            {
+                if (other[index] != this[index])
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
         /// Sets the entire grid to a specific <see cref="Color" />.
         /// </summary>
         /// <param name="color">The <see cref="Color" /> to apply.</param>
         [PublicAPI]
         public void Set(Color color)
         {
-            for (var row = 0; row < Constants.MaxRows; row++)
-                _rows[row].Set(color);
-        }
-
-        /// <summary>
-        /// Container struct holding color definitions for a single row in the custom grid.
-        /// </summary>
-        [StructLayout(LayoutKind.Sequential)]
-        private struct Row
-        {
-            /// <summary>
-            /// Color definitions for the columns of this row.
-            /// </summary>
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.MaxColumns)]
-            private readonly uint[] _columns;
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="Row" /> struct.
-            /// </summary>
-            /// <param name="colors">Colors for this row.</param>
-            internal Row(IList<Color> colors)
-            {
-                if (colors.Count != Constants.MaxColumns)
-                {
-                    throw new ArgumentException(
-                        "Incorrect color count, expected " + Constants.MaxColumns + " but received " + colors.Count,
-                        nameof(colors));
-                }
-
-                _columns = new uint[Constants.MaxColumns];
-
-                for (var col = 0; col < Constants.MaxColumns; col++)
-                    _columns[col] = colors[col];
-            }
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="Row" /> struct
-            /// setting each column to a specific color.
-            /// </summary>
-            /// <param name="color">The <see cref="Color" /> to set each column to.</param>
-            internal Row(Color color)
-            {
-                _columns = new uint[Constants.MaxColumns];
-
-                for (var col = 0; col < Constants.MaxColumns; col++)
-                    _columns[col] = color;
-            }
-
-            /// <summary>
-            /// Gets or sets a column's <see cref="Color" />.
-            /// </summary>
-            /// <param name="column">The column index to access (zero-index).</param>
-            /// <returns>The <see cref="Color" /> at the specified column index.</returns>
-            internal Color this[int column]
-            {
-                get
-                {
-                    if (column < 0 || column >= Constants.MaxColumns)
-                    {
-                        throw new ArgumentOutOfRangeException(
-                            nameof(column),
-                            column,
-                            "Attempted to access a column that does not exist.");
-                    }
-
-                    return _columns[column];
-                }
-
-                set
-                {
-                    if (column < 0 || column >= Constants.MaxColumns)
-                    {
-                        throw new ArgumentOutOfRangeException(
-                            nameof(column),
-                            column,
-                            "Attempted to access a column that does not exist.");
-                    }
-
-                    _columns[column] = value;
-                }
-            }
-
-            /// <summary>
-            /// Converts an instance of the <see cref="Row" /> struct to an array of unsigned integers.
-            /// </summary>
-            /// <param name="row">The <see cref="Row" /> object to convert.</param>
-            /// <returns>An array of unsigned integeres representing the colors of the row.</returns>
-            public static implicit operator uint[](Row row)
-            {
-                return row._columns;
-            }
-
-            /// <summary>
-            /// Returns the hash code for this instance.
-            /// </summary>
-            /// <returns>
-            /// A 32-bit signed integer that is the hash code for this instance.
-            /// </returns>
-            /// <filterpriority>2</filterpriority>
-            public override int GetHashCode()
-            {
-                return _columns?.GetHashCode() ?? 0;
-            }
-
-            /// <summary>
-            /// Sets the entire row to a specific <see cref="Color" />.
-            /// </summary>
-            /// <param name="color">The <see cref="Color" /> to apply.</param>
-            public void Set(Color color)
-            {
-                for (var column = 0; column < Constants.MaxColumns; column++)
-                    _columns[column] = color;
-            }
+            for (var index = 0; index < Constants.MaxKeys; index++)
+                _colors[index] = color;
         }
     }
 }

--- a/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
@@ -60,7 +60,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
             if (rows != Constants.MaxRows)
             {
                 throw new ArgumentException(
-                    "Colors array has incorrect number of rows, should be " + Constants.MaxRows + ", received " + rows,
+                    $"Colors array has incorrect number of rows, should be {Constants.MaxRows}, received {rows}.",
                     nameof(colors));
             }
 

--- a/Corale.Colore/Razer/Keypad/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keypad/Effects/Custom.cs
@@ -41,8 +41,9 @@ namespace Corale.Colore.Razer.Keypad.Effects
         /// Color definitions for each key on the keypad.
         /// </summary>
         /// <remarks>
-        /// The array is 2-dimensional, with the first dimension
-        /// specifying the row for the key, and the second the column.
+        /// The array is 1-dimensional, but will be passed to code expecting
+        /// a 2-dimensional array. Access to this array is done using indices
+        /// according to: <c>column + row * Constants.MaxColumns</c>
         /// </remarks>
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.MaxKeys)]
         private readonly Color[] _colors;

--- a/Corale.Colore/Razer/Keypad/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keypad/Effects/Custom.cs
@@ -109,7 +109,7 @@ namespace Corale.Colore.Razer.Keypad.Effects
             _colors = new Color[Constants.MaxKeys];
 
             for (var index = 0; index < Constants.MaxKeys; index++)
-                _colors[index] = color;
+                this[index] = color;
         }
 
         /// <summary>

--- a/Corale.Colore/Razer/Keypad/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keypad/Effects/Custom.cs
@@ -139,7 +139,9 @@ namespace Corale.Colore.Razer.Keypad.Effects
                         "Attempted to access a column that does not exist.");
                 }
 
+#pragma warning disable SA1407 // Arithmetic expressions must declare precedence
                 return _colors[column + row * Constants.MaxColumns];
+#pragma warning restore SA1407 // Arithmetic expressions must declare precedence
             }
 
             set
@@ -160,7 +162,9 @@ namespace Corale.Colore.Razer.Keypad.Effects
                         "Attempted to access a column that does not exist.");
                 }
 
+#pragma warning disable SA1407 // Arithmetic expressions must declare precedence
                 _colors[column + row * Constants.MaxColumns] = value;
+#pragma warning restore SA1407 // Arithmetic expressions must declare precedence
             }
         }
 

--- a/Corale.Colore/Razer/Keypad/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keypad/Effects/Custom.cs
@@ -26,7 +26,6 @@
 namespace Corale.Colore.Razer.Keypad.Effects
 {
     using System;
-    using System.Collections.Generic;
     using System.Runtime.InteropServices;
 
     using Corale.Colore.Annotations;
@@ -36,7 +35,7 @@ namespace Corale.Colore.Razer.Keypad.Effects
     /// Custom effect.
     /// </summary>
     [StructLayout(LayoutKind.Sequential)]
-    public struct Custom : IEquatable<Custom>, IEquatable<Color[][]>
+    public struct Custom : IEquatable<Custom>, IEquatable<Color[][]>, IEquatable<Color[]>
     {
         /// <summary>
         /// Color definitions for each key on the keypad.
@@ -45,8 +44,8 @@ namespace Corale.Colore.Razer.Keypad.Effects
         /// The array is 2-dimensional, with the first dimension
         /// specifying the row for the key, and the second the column.
         /// </remarks>
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.MaxRows)]
-        private readonly Row[] _rows;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.MaxKeys)]
+        private readonly Color[] _colors;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Custom" /> struct.
@@ -60,17 +59,44 @@ namespace Corale.Colore.Razer.Keypad.Effects
             if (rows != Constants.MaxRows)
             {
                 throw new ArgumentException(
-                    "Colors array has incorrect number of rows, should be " + Constants.MaxRows + ", received " + rows,
+                    $"Colors array has incorrect number of rows, should be {Constants.MaxRows}, received {rows}.",
                     nameof(colors));
             }
 
-            _rows = new Row[Constants.MaxRows];
+            _colors = new Color[Constants.MaxKeys];
 
             for (var row = 0; row < Constants.MaxRows; row++)
             {
-                var inRow = colors[row];
-                _rows[row] = new Row(inRow);
+                if (colors[row].Length != Constants.MaxColumns)
+                {
+                    throw new ArgumentException(
+                        $"Colors array has incorrect number of columns, should be {Constants.MaxColumns}, received {colors[row].Length} for row {row}.",
+                        nameof(colors));
+                }
+
+                for (var column = 0; column < Constants.MaxColumns; column++)
+                    this[row, column] = colors[row][column];
             }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Custom" /> struct.
+        /// </summary>
+        /// <param name="colors">The colors to use.</param>
+        /// <exception cref="ArgumentException">Thrown if the colors array supplied is of an invalid size.</exception>
+        public Custom(Color[] colors)
+        {
+            if (colors.Length != Constants.MaxKeys)
+            {
+                throw new ArgumentException(
+                    $"Colors array has incorrect size, should be {Constants.MaxKeys}, actual is {colors.Length}.",
+                    nameof(colors));
+            }
+
+            _colors = new Color[Constants.MaxKeys];
+
+            for (var index = 0; index < Constants.MaxKeys; index++)
+                this[index] = colors[index];
         }
 
         /// <summary>
@@ -80,10 +106,10 @@ namespace Corale.Colore.Razer.Keypad.Effects
         /// <param name="color">The <see cref="Color" /> to set each position to.</param>
         public Custom(Color color)
         {
-            _rows = new Row[Constants.MaxRows];
+            _colors = new Color[Constants.MaxKeys];
 
-            for (var row = 0; row < Constants.MaxRows; row++)
-                _rows[row] = new Row(color);
+            for (var index = 0; index < Constants.MaxKeys; index++)
+                _colors[index] = color;
         }
 
         /// <summary>
@@ -105,7 +131,15 @@ namespace Corale.Colore.Razer.Keypad.Effects
                         "Attempted to access a row that does not exist.");
                 }
 
-                return _rows[row][column];
+                if (column < 0 || column >= Constants.MaxColumns)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(column),
+                        column,
+                        "Attempted to access a column that does not exist.");
+                }
+
+                return _colors[column + row * Constants.MaxColumns];
             }
 
             set
@@ -118,7 +152,50 @@ namespace Corale.Colore.Razer.Keypad.Effects
                         "Attempted to access a row that does not exist.");
                 }
 
-                _rows[row][column] = value;
+                if (column < 0 || column >= Constants.MaxColumns)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(column),
+                        column,
+                        "Attempted to access a column that does not exist.");
+                }
+
+                _colors[column + row * Constants.MaxColumns] = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a position in the custom grid.
+        /// </summary>
+        /// <param name="index">The index to access, zero indexed.</param>
+        /// <returns>The <see cref="Color" /> at the specified position.</returns>
+        [PublicAPI]
+        public Color this[int index]
+        {
+            get
+            {
+                if (index < 0 || index >= Constants.MaxKeys)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(index),
+                        index,
+                        "Attempted to access an index that does not exist.");
+                }
+
+                return _colors[index];
+            }
+
+            set
+            {
+                if (index < 0 || index >= Constants.MaxKeys)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(index),
+                        index,
+                        "Attempted to access an index that does not exist.");
+                }
+
+                _colors[index] = value;
             }
         }
 
@@ -166,7 +243,7 @@ namespace Corale.Colore.Razer.Keypad.Effects
         /// <filterpriority>2</filterpriority>
         public override int GetHashCode()
         {
-            return _rows?.GetHashCode() ?? 0;
+            return _colors?.GetHashCode() ?? 0;
         }
 
         /// <summary>
@@ -175,8 +252,8 @@ namespace Corale.Colore.Razer.Keypad.Effects
         /// <param name="color">The <see cref="Color" /> to set.</param>
         public void Set(Color color)
         {
-            for (var row = 0; row < Constants.MaxRows; row++)
-                _rows[row].Set(color);
+            for (var index = 0; index < Constants.MaxKeys; index++)
+                this[index] = color;
         }
 
         /// <summary>
@@ -205,8 +282,14 @@ namespace Corale.Colore.Razer.Keypad.Effects
             if (obj is Custom)
                 return Equals((Custom)obj);
 
-            var arr = obj as Color[][];
-            return arr != null && Equals(arr);
+            var arr2D = obj as Color[][];
+
+            if (arr2D != null)
+                return Equals(arr2D);
+
+            var arr1D = obj as Color[];
+
+            return arr1D != null && Equals(arr1D);
         }
 
         /// <summary>
@@ -263,114 +346,26 @@ namespace Corale.Colore.Razer.Keypad.Effects
         }
 
         /// <summary>
-        /// Container struct holding color definitions for a single row in the custom grid.
+        /// Indicates whether the current object is equal to an instance of
+        /// an array of <see cref="Color" />.
         /// </summary>
-        [StructLayout(LayoutKind.Sequential)]
-        private struct Row
+        /// <param name="other">An array of <see cref="Color" /> to compare with this object.</param>
+        /// <returns>
+        /// <c>true</c> if the <paramref name="other" /> object has the same
+        /// number of elements, and contain matching colors; otherwise, <c>false</c>.
+        /// </returns>
+        public bool Equals(Color[] other)
         {
-            /// <summary>
-            /// Color definitions for the columns of this row.
-            /// </summary>
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.MaxColumns)]
-            private readonly uint[] _columns;
+            if (other == null || other.Length != Constants.MaxKeys)
+                return false;
 
-            /// <summary>
-            /// Initializes a new instance of the <see cref="Row" /> struct.
-            /// </summary>
-            /// <param name="colors">Colors for this row.</param>
-            internal Row(IList<Color> colors)
+            for (var index = 0; index < Constants.MaxKeys; index++)
             {
-                if (colors.Count != Constants.MaxColumns)
-                {
-                    throw new ArgumentException(
-                        "Incorrect color count, expected " + Constants.MaxColumns + " but received " + colors.Count,
-                        nameof(colors));
-                }
-
-                _columns = new uint[Constants.MaxColumns];
-
-                for (var col = 0; col < Constants.MaxColumns; col++)
-                    _columns[col] = colors[col];
+                if (other[index] != this[index])
+                    return false;
             }
 
-            /// <summary>
-            /// Initializes a new instance of the <see cref="Row" /> struct
-            /// setting each column to a specific color.
-            /// </summary>
-            /// <param name="color">The <see cref="Color" /> to set each column to.</param>
-            internal Row(Color color)
-            {
-                _columns = new uint[Constants.MaxColumns];
-
-                for (var col = 0; col < Constants.MaxColumns; col++)
-                    _columns[col] = color;
-            }
-
-            /// <summary>
-            /// Gets or sets a column's <see cref="Color" />.
-            /// </summary>
-            /// <param name="column">The column index to access (zero-index).</param>
-            /// <returns>The <see cref="Color" /> at the specified column index.</returns>
-            internal Color this[int column]
-            {
-                get
-                {
-                    if (column < 0 || column >= Constants.MaxColumns)
-                    {
-                        throw new ArgumentOutOfRangeException(
-                            nameof(column),
-                            column,
-                            "Attempted to access a column that does not exist.");
-                    }
-
-                    return _columns[column];
-                }
-
-                set
-                {
-                    if (column < 0 || column >= Constants.MaxColumns)
-                    {
-                        throw new ArgumentOutOfRangeException(
-                            nameof(column),
-                            column,
-                            "Attempted to access a column that does not exist.");
-                    }
-
-                    _columns[column] = value;
-                }
-            }
-
-            /// <summary>
-            /// Converts an instance of the <see cref="Row" /> struct to an array of unsigned integers.
-            /// </summary>
-            /// <param name="row">The <see cref="Row" /> object to convert.</param>
-            /// <returns>An array of unsigned integeres representing the colors of the row.</returns>
-            public static implicit operator uint[](Row row)
-            {
-                return row._columns;
-            }
-
-            /// <summary>
-            /// Returns the hash code for this instance.
-            /// </summary>
-            /// <returns>
-            /// A 32-bit signed integer that is the hash code for this instance.
-            /// </returns>
-            /// <filterpriority>2</filterpriority>
-            public override int GetHashCode()
-            {
-                return _columns?.GetHashCode() ?? 0;
-            }
-
-            /// <summary>
-            /// Sets the entire row to a specific <see cref="Color" />.
-            /// </summary>
-            /// <param name="color">The <see cref="Color" /> to apply.</param>
-            public void Set(Color color)
-            {
-                for (var column = 0; column < Constants.MaxColumns; column++)
-                    _columns[column] = color;
-            }
+            return true;
         }
     }
 }

--- a/Corale.Colore/Razer/Mouse/Constants.cs
+++ b/Corale.Colore/Razer/Mouse/Constants.cs
@@ -44,5 +44,10 @@ namespace Corale.Colore.Razer.Mouse
         /// Maximum number of LED columns.
         /// </summary>
         public const int MaxColumns = 7;
+
+        /// <summary>
+        /// Maximum number of LEDs on the grid layout.
+        /// </summary>
+        public const int MaxGridLeds = MaxRows * MaxColumns;
     }
 }

--- a/Corale.Colore/Razer/Mouse/Effects/CustomGrid.cs
+++ b/Corale.Colore/Razer/Mouse/Effects/CustomGrid.cs
@@ -26,7 +26,6 @@
 namespace Corale.Colore.Razer.Mouse.Effects
 {
     using System;
-    using System.Collections.Generic;
     using System.Runtime.InteropServices;
 
     using Corale.Colore.Annotations;
@@ -35,17 +34,18 @@ namespace Corale.Colore.Razer.Mouse.Effects
     /// <summary>
     /// Custom grid effect for mouse LEDs.
     /// </summary>
-    public struct CustomGrid : IEquatable<CustomGrid>, IEquatable<Color[][]>
+    public struct CustomGrid : IEquatable<CustomGrid>, IEquatable<Color[][]>, IEquatable<Color[]>
     {
         /// <summary>
         /// Color definitions for each led on the mouse.
         /// </summary>
         /// <remarks>
-        /// The array is 2-dimensional, with the first dimension
-        /// specifying the row for the led, and the second the column.
+        /// The array is 1-dimensional, but will be passed to code expecting
+        /// a 2-dimensional array. Access to this array is done using indices
+        /// according to: <c>column + row * Constants.MaxColumns</c>
         /// </remarks>
-        [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.MaxRows)]
-        private readonly Row[] _rows;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.MaxGridLeds)]
+        private readonly Color[] _colors;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CustomGrid" /> struct.
@@ -59,17 +59,44 @@ namespace Corale.Colore.Razer.Mouse.Effects
             if (rows != Constants.MaxRows)
             {
                 throw new ArgumentException(
-                    "Colors array has incorrect number of rows, should be " + Constants.MaxRows + ", received " + rows,
+                    $"Colors array has incorrect number of rows, should be {Constants.MaxRows}, received {rows}.",
                     nameof(colors));
             }
 
-            _rows = new Row[Constants.MaxRows];
+            _colors = new Color[Constants.MaxGridLeds];
 
             for (var row = 0; row < Constants.MaxRows; row++)
             {
-                var inRow = colors[row];
-                _rows[row] = new Row(inRow);
+                if (colors[row].Length != Constants.MaxColumns)
+                {
+                    throw new ArgumentException(
+                        $"Colors array has incorrect number of columns, should be {Constants.MaxColumns}, received {colors[row].Length} for row {row}.",
+                        nameof(colors));
+                }
+
+                for (var column = 0; column < Constants.MaxColumns; column++)
+                    this[row, column] = colors[row][column];
             }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CustomGrid" /> struct.
+        /// </summary>
+        /// <param name="colors">The colors to use.</param>
+        /// <exception cref="ArgumentException">Thrown if the colors array supplied is of an invalid size.</exception>
+        public CustomGrid(Color[] colors)
+        {
+            if (colors.Length != Constants.MaxGridLeds)
+            {
+                throw new ArgumentException(
+                    $"Colors array has incorrect size, should be {Constants.MaxGridLeds}, actual is {colors.Length}.",
+                    nameof(colors));
+            }
+
+            _colors = new Color[Constants.MaxGridLeds];
+
+            for (var index = 0; index < Constants.MaxGridLeds; index++)
+                this[index] = colors[index];
         }
 
         /// <summary>
@@ -79,10 +106,10 @@ namespace Corale.Colore.Razer.Mouse.Effects
         /// <param name="color">The <see cref="Color" /> to set each position to.</param>
         public CustomGrid(Color color)
         {
-            _rows = new Row[Constants.MaxRows];
+            _colors = new Color[Constants.MaxGridLeds];
 
-            for (var row = 0; row < Constants.MaxRows; row++)
-                _rows[row] = new Row(color);
+            for (var index = 0; index < Constants.MaxGridLeds; index++)
+                this[index] = color;
         }
 
         /// <summary>
@@ -97,17 +124,82 @@ namespace Corale.Colore.Razer.Mouse.Effects
             get
             {
                 if (row < 0 || row >= Constants.MaxRows)
-                    throw new ArgumentOutOfRangeException(nameof(row), row, "Attempted to access a row that does not exist.");
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(row),
+                        row,
+                        "Attempted to access a row that does not exist.");
+                }
 
-                return _rows[row][column];
+                if (column < 0 || column >= Constants.MaxColumns)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(column),
+                        column,
+                        "Attempted to access a column that does not exist.");
+                }
+
+#pragma warning disable SA1407 // Arithmetic expressions must declare precedence
+                return _colors[column + row * Constants.MaxColumns];
+#pragma warning restore SA1407 // Arithmetic expressions must declare precedence
             }
 
             set
             {
                 if (row < 0 || row >= Constants.MaxRows)
-                    throw new ArgumentOutOfRangeException(nameof(row), row, "Attempted to access a row that does not exist.");
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(row),
+                        row,
+                        "Attempted to access a row that does not exist.");
+                }
 
-                _rows[row][column] = value;
+                if (column < 0 || column >= Constants.MaxColumns)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(column),
+                        column,
+                        "Attempted to access a column that does not exist.");
+                }
+
+#pragma warning disable SA1407 // Arithmetic expressions must declare precedence
+                _colors[column + row * Constants.MaxColumns] = value;
+#pragma warning restore SA1407 // Arithmetic expressions must declare precedence
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a position in the custom grid.
+        /// </summary>
+        /// <param name="index">The index to access, zero indexed.</param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the requested index is out of range.</exception>
+        [PublicAPI]
+        public Color this[int index]
+        {
+            get
+            {
+                if (index < 0 || index >= Constants.MaxGridLeds)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(index),
+                        index,
+                        "Attempted to access an index that does not exist.");
+                }
+
+                return _colors[index];
+            }
+
+            set
+            {
+                if (index < 0 || index >= Constants.MaxGridLeds)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(index),
+                        index,
+                        "Attempted to access an index that does not exist.");
+                }
+
+                _colors[index] = value;
             }
         }
 
@@ -177,7 +269,7 @@ namespace Corale.Colore.Razer.Mouse.Effects
         /// </returns>
         public override int GetHashCode()
         {
-            return _rows?.GetHashCode() ?? 0;
+            return _colors?.GetHashCode() ?? 0;
         }
 
         /// <summary>
@@ -205,8 +297,14 @@ namespace Corale.Colore.Razer.Mouse.Effects
             if (obj is CustomGrid)
                 return Equals((CustomGrid)obj);
 
-            var arr = obj as Color[][];
-            return arr != null && Equals(arr);
+            var arr2D = obj as Color[][];
+
+            if (arr2D != null)
+                return Equals(arr2D);
+
+            var arr1D = obj as Color[];
+
+            return arr1D != null && Equals(arr1D);
         }
 
         /// <summary>
@@ -263,125 +361,37 @@ namespace Corale.Colore.Razer.Mouse.Effects
         }
 
         /// <summary>
+        /// Indicates whether the current object is equal to an instance of
+        /// an array of <see cref="Color" />.
+        /// </summary>
+        /// <param name="other">An array of <see cref="Color" /> to compare with this object.</param>
+        /// <returns>
+        /// <c>true</c> if the <paramref name="other" /> object has the same
+        /// number of elements, and contain matching colors; otherwise, <c>false</c>.
+        /// </returns>
+        public bool Equals(Color[] other)
+        {
+            if (other == null || other.Length != Constants.MaxGridLeds)
+                return false;
+
+            for (var index = 0; index < Constants.MaxColumns; index++)
+            {
+                if (this[index] != other[index])
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
         /// Sets the entire grid to a specific <see cref="Color" />.
         /// </summary>
         /// <param name="color">The <see cref="Color" /> to apply.</param>
         [PublicAPI]
         public void Set(Color color)
         {
-            for (var row = 0; row < Constants.MaxRows; row++)
-                _rows[row].Set(color);
-        }
-
-        /// <summary>
-        /// Container struct holding color definitions for a single row in the custom grid.
-        /// </summary>
-        [StructLayout(LayoutKind.Sequential)]
-        private struct Row
-        {
-            /// <summary>
-            /// Color definitions for the columns of this row.
-            /// </summary>
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.MaxColumns)]
-            private readonly uint[] _columns;
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="Row" /> struct.
-            /// </summary>
-            /// <param name="colors">Colors for this row.</param>
-            internal Row(IList<Color> colors)
-            {
-                if (colors.Count != Constants.MaxColumns)
-                {
-                    throw new ArgumentException(
-                        "Incorrect color count, expected " + Constants.MaxColumns + " but received " + colors.Count,
-                        nameof(colors));
-                }
-
-                _columns = new uint[Constants.MaxColumns];
-
-                for (var col = 0; col < Constants.MaxColumns; col++)
-                    _columns[col] = colors[col];
-            }
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="Row" /> struct
-            /// setting each column to a specific color.
-            /// </summary>
-            /// <param name="color">The <see cref="Color" /> to set each column to.</param>
-            internal Row(Color color)
-            {
-                _columns = new uint[Constants.MaxColumns];
-
-                for (var col = 0; col < Constants.MaxColumns; col++)
-                    _columns[col] = color;
-            }
-
-            /// <summary>
-            /// Gets or sets a column's <see cref="Color" />.
-            /// </summary>
-            /// <param name="column">The column index to access (zero-index).</param>
-            /// <returns>The <see cref="Color" /> at the specified column index.</returns>
-            internal Color this[int column]
-            {
-                get
-                {
-                    if (column < 0 || column >= Constants.MaxColumns)
-                    {
-                        throw new ArgumentOutOfRangeException(
-                            nameof(column),
-                            column,
-                            "Attempted to access a column that does not exist.");
-                    }
-
-                    return _columns[column];
-                }
-
-                set
-                {
-                    if (column < 0 || column >= Constants.MaxColumns)
-                    {
-                        throw new ArgumentOutOfRangeException(
-                            nameof(column),
-                            column,
-                            "Attempted to access a column that does not exist.");
-                    }
-
-                    _columns[column] = value;
-                }
-            }
-
-            /// <summary>
-            /// Converts an instance of the <see cref="Row" /> struct to an array of unsigned integers.
-            /// </summary>
-            /// <param name="row">The <see cref="Row" /> object to convert.</param>
-            /// <returns>An array of unsigned integeres representing the colors of the row.</returns>
-            public static implicit operator uint[](Row row)
-            {
-                return row._columns;
-            }
-
-            /// <summary>
-            /// Returns the hash code for this instance.
-            /// </summary>
-            /// <returns>
-            /// A 32-bit signed integer that is the hash code for this instance.
-            /// </returns>
-            /// <filterpriority>2</filterpriority>
-            public override int GetHashCode()
-            {
-                return _columns?.GetHashCode() ?? 0;
-            }
-
-            /// <summary>
-            /// Sets the entire row to a specific <see cref="Color" />.
-            /// </summary>
-            /// <param name="color">The <see cref="Color" /> to apply.</param>
-            public void Set(Color color)
-            {
-                for (var column = 0; column < Constants.MaxColumns; column++)
-                    _columns[column] = color;
-            }
+            for (var index = 0; index < Constants.MaxGridLeds; index++)
+                this[index] = color;
         }
     }
 }


### PR DESCRIPTION
The convoluted design with a `Row` struct to achieve two-dimensional arrays that can be passed to unmanaged code for the custom grid effects have been replaced with one-dimensional arrays.

This should make code more performant and simplify the design of grid effects.

The issue with the massive code duplication between custom grid effects is still an issue we should look into improving.

:warning: **This code has not been tested to work on keypads!**

I have tested it for the keyboard and mouse grid effects, but I don't have a keypad so can't test for those. I don't expect there would be any issues but we should test it on those before merging.

If @brandonscott or @njbmartin have ability to test on keypads that would be great.