### PR TITLE
Add ways to copy custom structs

### DIFF
--- a/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
+++ b/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
@@ -493,5 +493,25 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
 
             Assert.AreEqual(Color.Red, grid[Key.Escape]);
         }
+
+        [Test]
+        public void ClonedStructShouldBeIdentical()
+        {
+            var original = new Custom(Color.Red);
+            var clone = original.Clone();
+
+            Assert.That(clone, Is.EqualTo(original));
+        }
+
+        [Test]
+        public void ClonedStructShouldBeIndependent()
+        {
+            var original = new Custom(Color.Red);
+            var clone = original.Clone();
+
+            clone.Set(Color.Blue);
+
+            Assert.That(clone, Is.Not.EqualTo(original));
+        }
     }
 }

--- a/Corale.Colore.Tests/Razer/Keypad/Effects/CustomTests.cs
+++ b/Corale.Colore.Tests/Razer/Keypad/Effects/CustomTests.cs
@@ -487,5 +487,25 @@ namespace Corale.Colore.Tests.Razer.Keypad.Effects
 
             Assert.AreEqual(Color.Red, grid[5]);
         }
+
+        [Test]
+        public void ClonedStructShouldBeIdentical()
+        {
+            var original = new Custom(Color.Red);
+            var clone = original.Clone();
+
+            Assert.That(clone, Is.EqualTo(original));
+        }
+
+        [Test]
+        public void ClonedStructShouldBeIndependent()
+        {
+            var original = new Custom(Color.Red);
+            var clone = original.Clone();
+
+            clone.Set(Color.Blue);
+
+            Assert.That(clone, Is.Not.EqualTo(original));
+        }
     }
 }

--- a/Corale.Colore.Tests/Razer/Mouse/Effects/CustomGridTests.cs
+++ b/Corale.Colore.Tests/Razer/Mouse/Effects/CustomGridTests.cs
@@ -482,5 +482,25 @@ namespace Corale.Colore.Tests.Razer.Mouse.Effects
             Assert.False(effect.Equals((Color[])null));
             Assert.AreNotEqual(effect, null);
         }
+
+        [Test]
+        public void ClonedStructShouldBeIdentical()
+        {
+            var original = new CustomGrid(Color.Red);
+            var clone = original.Clone();
+
+            Assert.That(clone, Is.EqualTo(original));
+        }
+
+        [Test]
+        public void ClonedStructShouldBeIndependent()
+        {
+            var original = new CustomGrid(Color.Red);
+            var clone = original.Clone();
+
+            clone.Set(Color.Blue);
+
+            Assert.That(clone, Is.Not.EqualTo(original));
+        }
     }
 }

--- a/Corale.Colore.Tests/Razer/Mouse/Effects/CustomTests.cs
+++ b/Corale.Colore.Tests/Razer/Mouse/Effects/CustomTests.cs
@@ -288,5 +288,25 @@ namespace Corale.Colore.Tests.Razer.Mouse.Effects
             Assert.False(effect.Equals(null));
             Assert.AreNotEqual(effect, null);
         }
+
+        [Test]
+        public void ClonedStructShouldBeIdentical()
+        {
+            var original = new Custom(Color.Red);
+            var clone = original.Clone();
+
+            Assert.That(clone, Is.EqualTo(original));
+        }
+
+        [Test]
+        public void ClonedStructShouldBeIndependent()
+        {
+            var original = new Custom(Color.Red);
+            var clone = original.Clone();
+
+            clone.Set(Color.Blue);
+
+            Assert.That(clone, Is.Not.EqualTo(original));
+        }
     }
 }

--- a/Corale.Colore.Tests/Razer/Mousepad/Effects/CustomTests.cs
+++ b/Corale.Colore.Tests/Razer/Mousepad/Effects/CustomTests.cs
@@ -256,5 +256,25 @@ namespace Corale.Colore.Tests.Razer.Mousepad.Effects
             Assert.False(effect.Equals(null));
             Assert.AreNotEqual(effect, null);
         }
+
+        [Test]
+        public void ClonedStructShouldBeIdentical()
+        {
+            var original = new Custom(Color.Red);
+            var clone = original.Clone();
+
+            Assert.That(clone, Is.EqualTo(original));
+        }
+
+        [Test]
+        public void ClonedStructShouldBeIndependent()
+        {
+            var original = new Custom(Color.Red);
+            var clone = original.Clone();
+
+            clone.Set(Color.Blue);
+
+            Assert.That(clone, Is.Not.EqualTo(original));
+        }
     }
 }

--- a/Corale.Colore.ruleset
+++ b/Corale.Colore.ruleset
@@ -64,6 +64,9 @@
     <Rule Id="CA2241" Action="Warning" />
     <Rule Id="CA2242" Action="Warning" />
   </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+    <Rule Id="IDE0001" Action="None" />
+  </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA1101" Action="None" />
     <Rule Id="SA1117" Action="None" />

--- a/Corale.Colore.sln.DotSettings
+++ b/Corale.Colore.sln.DotSettings
@@ -229,6 +229,7 @@
     &lt;/Entry&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
 &lt;/Patterns&gt;</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CSharpUsing/PreferQualifiedReference/@EntryValue">False</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">---------------------------------------------------------------------------------------&#xD;
 &lt;copyright file="$FILENAME$" company="Corale"&gt;&#xD;
     Copyright © 2015 by Adam Hellberg and Brandon Scott.&#xD;

--- a/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
@@ -26,6 +26,7 @@
 namespace Corale.Colore.Razer.Keyboard.Effects
 {
     using System;
+    using System.Collections.Generic;
     using System.Runtime.InteropServices;
 
     using Corale.Colore.Annotations;
@@ -85,12 +86,12 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         /// </summary>
         /// <param name="colors">The colors to use.</param>
         /// <exception cref="ArgumentException">Thrown if the colors array supplied is of an incorrect size.</exception>
-        public Custom(Color[] colors)
+        public Custom(IList<Color> colors)
         {
-            if (colors.Length != Constants.MaxKeys)
+            if (colors.Count != Constants.MaxKeys)
             {
                 throw new ArgumentException(
-                    $"Colors array has incorrect size, should be {Constants.MaxKeys}, actual is {colors.Length}.",
+                    $"Colors array has incorrect size, should be {Constants.MaxKeys}, actual is {colors.Count}.",
                     nameof(colors));
             }
 

--- a/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
@@ -114,6 +114,16 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Custom" /> struct
+        /// with the colors copied from another struct of the same type.
+        /// </summary>
+        /// <param name="other">The <see cref="Custom" /> struct to copy data from.</param>
+        public Custom(Custom other)
+            : this(other._colors)
+        {
+        }
+
+        /// <summary>
         /// Gets or sets cells in the custom grid.
         /// </summary>
         /// <param name="row">Row to access, zero indexed.</param>
@@ -264,6 +274,16 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         public static Custom Create()
         {
             return new Custom(Color.Black);
+        }
+
+        /// <summary>
+        /// Returns a copy of this struct.
+        /// </summary>
+        /// <returns>A copy of this struct.</returns>
+        [PublicAPI]
+        public Custom Clone()
+        {
+            return new Custom(this);
         }
 
         /// <summary>

--- a/Corale.Colore/Razer/Keypad/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keypad/Effects/Custom.cs
@@ -26,6 +26,7 @@
 namespace Corale.Colore.Razer.Keypad.Effects
 {
     using System;
+    using System.Collections.Generic;
     using System.Runtime.InteropServices;
 
     using Corale.Colore.Annotations;
@@ -85,12 +86,12 @@ namespace Corale.Colore.Razer.Keypad.Effects
         /// </summary>
         /// <param name="colors">The colors to use.</param>
         /// <exception cref="ArgumentException">Thrown if the colors array supplied is of an invalid size.</exception>
-        public Custom(Color[] colors)
+        public Custom(IList<Color> colors)
         {
-            if (colors.Length != Constants.MaxKeys)
+            if (colors.Count != Constants.MaxKeys)
             {
                 throw new ArgumentException(
-                    $"Colors array has incorrect size, should be {Constants.MaxKeys}, actual is {colors.Length}.",
+                    $"Colors array has incorrect size, should be {Constants.MaxKeys}, actual is {colors.Count}.",
                     nameof(colors));
             }
 

--- a/Corale.Colore/Razer/Keypad/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keypad/Effects/Custom.cs
@@ -114,6 +114,16 @@ namespace Corale.Colore.Razer.Keypad.Effects
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Custom" /> struct
+        /// with color values copied from another struct of the same type.
+        /// </summary>
+        /// <param name="other">The struct to copy data from.</param>
+        public Custom(Custom other)
+            : this(other._colors)
+        {
+        }
+
+        /// <summary>
         /// Gets or sets cells in the custom grid.
         /// </summary>
         /// <param name="row">Row to access, zero indexed.</param>
@@ -237,6 +247,16 @@ namespace Corale.Colore.Razer.Keypad.Effects
         public static Custom Create()
         {
             return new Custom(Color.Black);
+        }
+
+        /// <summary>
+        /// Returns a copy of this struct.
+        /// </summary>
+        /// <returns>A copy of this struct.</returns>
+        [PublicAPI]
+        public Custom Clone()
+        {
+            return new Custom(this);
         }
 
         /// <summary>

--- a/Corale.Colore/Razer/Mouse/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Mouse/Effects/Custom.cs
@@ -79,6 +79,16 @@ namespace Corale.Colore.Razer.Mouse.Effects
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Custom" /> struct
+        /// with the colors copied from another struct of the same type.
+        /// </summary>
+        /// <param name="other">The struct to copy data from.</param>
+        public Custom(Custom other)
+            : this(other._colors)
+        {
+        }
+
+        /// <summary>
         /// Gets or sets LEDs in the custom array.
         /// </summary>
         /// <param name="led">Index of the LED to access.</param>
@@ -170,6 +180,16 @@ namespace Corale.Colore.Razer.Mouse.Effects
         public static Custom Create()
         {
             return new Custom(Color.Black);
+        }
+
+        /// <summary>
+        /// Returns a copy of this struct.
+        /// </summary>
+        /// <returns>A copy of this struct.</returns>
+        [PublicAPI]
+        public Custom Clone()
+        {
+            return new Custom(this);
         }
 
         /// <summary>

--- a/Corale.Colore/Razer/Mouse/Effects/CustomGrid.cs
+++ b/Corale.Colore/Razer/Mouse/Effects/CustomGrid.cs
@@ -26,6 +26,7 @@
 namespace Corale.Colore.Razer.Mouse.Effects
 {
     using System;
+    using System.Collections.Generic;
     using System.Runtime.InteropServices;
 
     using Corale.Colore.Annotations;
@@ -84,12 +85,12 @@ namespace Corale.Colore.Razer.Mouse.Effects
         /// </summary>
         /// <param name="colors">The colors to use.</param>
         /// <exception cref="ArgumentException">Thrown if the colors array supplied is of an invalid size.</exception>
-        public CustomGrid(Color[] colors)
+        public CustomGrid(IList<Color> colors)
         {
-            if (colors.Length != Constants.MaxGridLeds)
+            if (colors.Count != Constants.MaxGridLeds)
             {
                 throw new ArgumentException(
-                    $"Colors array has incorrect size, should be {Constants.MaxGridLeds}, actual is {colors.Length}.",
+                    $"Colors array has incorrect size, should be {Constants.MaxGridLeds}, actual is {colors.Count}.",
                     nameof(colors));
             }
 

--- a/Corale.Colore/Razer/Mouse/Effects/CustomGrid.cs
+++ b/Corale.Colore/Razer/Mouse/Effects/CustomGrid.cs
@@ -113,6 +113,16 @@ namespace Corale.Colore.Razer.Mouse.Effects
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="CustomGrid" /> struct
+        /// with the colors copied from another struct of the same type.
+        /// </summary>
+        /// <param name="other">The <see cref="CustomGrid" /> struct to copy data from.</param>
+        public CustomGrid(CustomGrid other)
+            : this(other._colors)
+        {
+        }
+
+        /// <summary>
         /// Gets or sets cells in the <see cref="CustomGrid" />.
         /// </summary>
         /// <param name="row">Row to access, zero indexed.</param>
@@ -259,6 +269,16 @@ namespace Corale.Colore.Razer.Mouse.Effects
         public static CustomGrid Create()
         {
             return new CustomGrid(Color.Black);
+        }
+
+        /// <summary>
+        /// Returns a copy of this struct.
+        /// </summary>
+        /// <returns>A copy of this struct.</returns>
+        [PublicAPI]
+        public CustomGrid Clone()
+        {
+            return new CustomGrid(this);
         }
 
         /// <summary>

--- a/Corale.Colore/Razer/Mousepad/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Mousepad/Effects/Custom.cs
@@ -78,6 +78,16 @@ namespace Corale.Colore.Razer.Mousepad.Effects
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="Custom" /> struct
+        /// with the colors copied from another struct of the same type.
+        /// </summary>
+        /// <param name="other">The struct to copy data from.</param>
+        public Custom(Custom other)
+            : this(other._colors)
+        {
+        }
+
+        /// <summary>
         /// Gets or sets LEDs in the custom array.
         /// </summary>
         /// <param name="led">Index of the LED to access.</param>
@@ -144,6 +154,16 @@ namespace Corale.Colore.Razer.Mousepad.Effects
         public static Custom Create()
         {
             return new Custom(Color.Black);
+        }
+
+        /// <summary>
+        /// Returns a copy of this struct.
+        /// </summary>
+        /// <returns>A copy of this struct.</returns>
+        [PublicAPI]
+        public Custom Clone()
+        {
+            return new Custom(this);
         }
 
         /// <summary>


### PR DESCRIPTION
Implements #156.

This adds a new constructor to every `Custom` effect struct taking an object of the same type to initialize the same instance with.

Also added are `Clone()` methods on every `Custom` struct that gives back a new copy of the struct.

While doing this I also changed the constructors taking arrays to instead take an instance of an `IList<Color>` for greater flexibility. The `IDE0001` rule was also disabled since we currently use fully qualified names in `using` statements.