### PR TITLE
Implement the new CUSTOM_KEY grid

### DIFF
--- a/Corale.Colore.Tests/Core/ColorTests.cs
+++ b/Corale.Colore.Tests/Core/ColorTests.cs
@@ -55,13 +55,11 @@ namespace Corale.Colore.Tests.Core
             const byte R = 200;
             const byte G = 245;
             const byte B = 86;
-            const byte A = 128;
-            var c = new Color(R, G, B, A);
+            var c = new Color(R, G, B);
             Assert.AreEqual(c.Value, V);
             Assert.AreEqual(c.R, R);
             Assert.AreEqual(c.G, G);
             Assert.AreEqual(c.B, B);
-            Assert.AreEqual(c.A, A);
         }
 
         [Test]
@@ -71,17 +69,14 @@ namespace Corale.Colore.Tests.Core
             const double R = 0.8;
             const double G = 0.54;
             const double B = 0.24;
-            const double A = 0.5;
             const byte ExpectedR = (byte)(R * 255);
             const byte ExpectedG = (byte)(G * 255);
             const byte ExpectedB = (byte)(B * 255);
-            const byte ExpectedA = (byte)(A * 255);
-            var c = new Color(R, G, B, A);
+            var c = new Color(R, G, B);
             Assert.AreEqual(c.Value, V);
             Assert.AreEqual(c.R, ExpectedR);
             Assert.AreEqual(c.G, ExpectedG);
             Assert.AreEqual(c.B, ExpectedB);
-            Assert.AreEqual(c.A, ExpectedA);
         }
 
         [Test]
@@ -91,30 +86,14 @@ namespace Corale.Colore.Tests.Core
             const float R = 0.8f;
             const float G = 0.2f;
             const float B = 0.9f;
-            const float A = 0.85f;
             const byte ExpectedR = (byte)(R * 255);
             const byte ExpectedG = (byte)(G * 255);
             const byte ExpectedB = (byte)(B * 255);
-            const byte ExpectedA = (byte)(A * 255);
-            var c = new Color(R, G, B, A);
+            var c = new Color(R, G, B);
             Assert.AreEqual(c.Value, V);
             Assert.AreEqual(c.R, ExpectedR);
             Assert.AreEqual(c.G, ExpectedG);
             Assert.AreEqual(c.B, ExpectedB);
-            Assert.AreEqual(c.A, ExpectedA);
-        }
-
-        [Test]
-        public void ShouldConstructFromArgb()
-        {
-            var expected = new Color(0x12345678);
-            var actual = Color.FromArgb(0x12785634);
-
-            Assert.AreEqual(expected.Value, actual.Value);
-            Assert.AreEqual(expected.R, actual.R);
-            Assert.AreEqual(expected.G, actual.G);
-            Assert.AreEqual(expected.B, actual.B);
-            Assert.AreEqual(expected.A, actual.A);
         }
 
         [Test]
@@ -127,7 +106,6 @@ namespace Corale.Colore.Tests.Core
             Assert.AreEqual(expected.R, actual.R);
             Assert.AreEqual(expected.G, actual.G);
             Assert.AreEqual(expected.B, actual.B);
-            Assert.AreEqual(expected.A, actual.A);
         }
 
         [Test]
@@ -250,19 +228,17 @@ namespace Corale.Colore.Tests.Core
             Assert.AreEqual(source.R, coloreColor.R);
             Assert.AreEqual(source.G, coloreColor.G);
             Assert.AreEqual(source.B, coloreColor.B);
-            Assert.AreEqual(source.A, coloreColor.A);
         }
 
         [Test]
         public void ShouldExplicitCastToSystemColor()
         {
-            var coloreColor = new Color(1, 2, 4, 8);
+            var coloreColor = new Color(1, 2, 4);
             var systemColor = (SystemColor)coloreColor;
 
             Assert.AreEqual(coloreColor.R, systemColor.R);
             Assert.AreEqual(coloreColor.G, systemColor.G);
             Assert.AreEqual(coloreColor.B, systemColor.B);
-            Assert.AreEqual(coloreColor.A, systemColor.A);
         }
 
         [Test]
@@ -274,19 +250,17 @@ namespace Corale.Colore.Tests.Core
             Assert.AreEqual(systemColor.R, coloreColor.R);
             Assert.AreEqual(systemColor.G, coloreColor.G);
             Assert.AreEqual(systemColor.B, coloreColor.B);
-            Assert.AreEqual(systemColor.A, coloreColor.A);
         }
 
         [Test]
         public void ShouldImplicitCastToSystemColor()
         {
-            var coloreColor = new Color(1, 2, 4, 8);
+            var coloreColor = new Color(1, 2, 4);
             SystemColor systemColor = coloreColor;
 
             Assert.AreEqual(coloreColor.R, systemColor.R);
             Assert.AreEqual(coloreColor.G, systemColor.G);
             Assert.AreEqual(coloreColor.B, systemColor.B);
-            Assert.AreEqual(coloreColor.A, systemColor.A);
         }
 
         [Test]
@@ -298,13 +272,12 @@ namespace Corale.Colore.Tests.Core
             Assert.AreEqual(systemColor.R, coloreColor.R);
             Assert.AreEqual(systemColor.G, coloreColor.G);
             Assert.AreEqual(systemColor.B, coloreColor.B);
-            Assert.AreEqual(systemColor.A, coloreColor.A);
         }
 
         [Test]
         public void ShouldEqualSystemColorUsingOverload()
         {
-            var coloreColor = new Color(1, 2, 3, 8);
+            var coloreColor = new Color(1, 2, 3);
             var systemColor = SystemColor.FromArgb(8, 1, 2, 3);
 
             Assert.True(coloreColor.Equals(systemColor));
@@ -320,19 +293,17 @@ namespace Corale.Colore.Tests.Core
             Assert.AreEqual(wpfColor.R, coloreColor.R);
             Assert.AreEqual(wpfColor.G, coloreColor.G);
             Assert.AreEqual(wpfColor.B, coloreColor.B);
-            Assert.AreEqual(wpfColor.A, coloreColor.A);
         }
 
         [Test]
         public void ShouldExplicitCastToWpfColor()
         {
-            var coloreColor = new Color(1, 2, 4, 8);
+            var coloreColor = new Color(1, 2, 4);
             var wpfColor = (WpfColor)coloreColor;
 
             Assert.AreEqual(coloreColor.R, wpfColor.R);
             Assert.AreEqual(coloreColor.G, wpfColor.G);
             Assert.AreEqual(coloreColor.B, wpfColor.B);
-            Assert.AreEqual(coloreColor.A, wpfColor.A);
         }
 
         [Test]
@@ -344,19 +315,17 @@ namespace Corale.Colore.Tests.Core
             Assert.AreEqual(wpfColor.R, coloreColor.R);
             Assert.AreEqual(wpfColor.G, coloreColor.G);
             Assert.AreEqual(wpfColor.B, coloreColor.B);
-            Assert.AreEqual(wpfColor.A, coloreColor.A);
         }
 
         [Test]
         public void ShouldImplicitCastToWpfColor()
         {
-            var coloreColor = new Color(1, 2, 4, 8);
+            var coloreColor = new Color(1, 2, 4);
             WpfColor wpfColor = coloreColor;
 
             Assert.AreEqual(coloreColor.R, wpfColor.R);
             Assert.AreEqual(coloreColor.G, wpfColor.G);
             Assert.AreEqual(coloreColor.B, wpfColor.B);
-            Assert.AreEqual(coloreColor.A, wpfColor.A);
         }
 
         [Test]
@@ -368,17 +337,25 @@ namespace Corale.Colore.Tests.Core
             Assert.AreEqual(wpfColor.R, coloreColor.R);
             Assert.AreEqual(wpfColor.G, coloreColor.G);
             Assert.AreEqual(wpfColor.B, coloreColor.B);
-            Assert.AreEqual(wpfColor.A, coloreColor.A);
         }
 
         [Test]
         public void ShouldEqualWpfColorUsingOverload()
         {
-            var coloreColor = new Color(1, 2, 3, 8);
+            var coloreColor = new Color(1, 2, 3);
             var wpfColor = WpfColor.FromArgb(8, 1, 2, 3);
 
             Assert.True(coloreColor.Equals(wpfColor));
             Assert.AreEqual(coloreColor, wpfColor);
+        }
+
+        [Test]
+        public void ShouldNotIgnoreHigherBitsOnCompare()
+        {
+            Color a = 0x55123456;
+            Color b = 0x66123456;
+
+            Assert.That(a, Is.Not.EqualTo(b));
         }
     }
 }

--- a/Corale.Colore.Tests/Core/ColorTests.cs
+++ b/Corale.Colore.Tests/Core/ColorTests.cs
@@ -51,7 +51,7 @@ namespace Corale.Colore.Tests.Core
         [Test]
         public void ShouldConvertRgbBytesCorrectly()
         {
-            const uint V = 0x8056F5C8;
+            const uint V = 0x56F5C8;
             const byte R = 200;
             const byte G = 245;
             const byte B = 86;
@@ -65,7 +65,7 @@ namespace Corale.Colore.Tests.Core
         [Test]
         public void ShouldConvertRgbDoublesCorrectly()
         {
-            const uint V = 0x7F3D89CC;
+            const uint V = 0x3D89CC;
             const double R = 0.8;
             const double G = 0.54;
             const double B = 0.24;
@@ -82,7 +82,7 @@ namespace Corale.Colore.Tests.Core
         [Test]
         public void ShouldConvertRgbFloatsCorrectly()
         {
-            const uint V = 0xD8E533CC;
+            const uint V = 0xE533CC;
             const float R = 0.8f;
             const float G = 0.2f;
             const float B = 0.9f;
@@ -99,7 +99,7 @@ namespace Corale.Colore.Tests.Core
         [Test]
         public void ShouldConstructFromRgb()
         {
-            var expected = new Color(0xFF123456);
+            var expected = new Color(0x123456);
             var actual = Color.FromRgb(0x563412);
 
             Assert.AreEqual(expected.Value, actual.Value);
@@ -128,7 +128,7 @@ namespace Corale.Colore.Tests.Core
         public void ShouldEqualIdenticalUint()
         {
             var a = new Color(255, 0, 255);
-            const uint B = 0xFFFF00FF;
+            const uint B = 0xFF00FF;
             Assert.AreEqual(a, B);
             Assert.True(a == B);
             Assert.False(a != B);

--- a/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
+++ b/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
@@ -163,51 +163,6 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
         }
 
         [Test]
-        public void ShouldThrowWhenInvalid2DRowCount()
-        {
-            // We don't need to set up the columns as the code should throw before
-            // it reaches the point of iterating rows
-            var arr = new Color[2][];
-
-            // ReSharper disable once NotAccessedVariable
-            Custom dummy;
-
-            Assert.That(
-                () => dummy = new Custom(arr),
-                Throws.ArgumentException.With.Property("ParamName").EqualTo("colors"));
-        }
-
-        [Test]
-        public void ShouldThrowWhenInvalid2DColumnCount()
-        {
-            var arr = new Color[Constants.MaxRows][];
-
-            // We only need to populate one of the rows, as the
-            // code shouldn't check further anyway.
-            arr[0] = new Color[2];
-
-            // ReSharper disable once NotAccessedVariable
-            Custom dummy;
-
-            Assert.That(
-                () => dummy = new Custom(arr),
-                Throws.ArgumentException.With.Property("ParamName").EqualTo("colors"));
-        }
-
-        [Test]
-        public void ShouldThrowWhenInvalid1DSize()
-        {
-            var arr = new Color[2];
-
-            // ReSharper disable once NotAccessedVariable
-            Custom dummy;
-
-            Assert.That(
-                () => dummy = new Custom(arr),
-                Throws.ArgumentException.With.Property("ParamName").EqualTo("colors"));
-        }
-
-        [Test]
         public void ShouldSetToBlackWithCreate()
         {
             var grid = Custom.Create();
@@ -229,43 +184,6 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
                 for (var column = 0; column < Constants.MaxColumns; column++)
                     Assert.That(grid[row, column], Is.EqualTo(Color.Red));
             }
-        }
-
-        [Test]
-        public void ShouldSetProperColorsWith2DCtor()
-        {
-            var arr = new Color[Constants.MaxRows][];
-
-            for (var row = 0; row < Constants.MaxRows; row++)
-                arr[row] = new Color[Constants.MaxColumns];
-
-            // Set some arbitrary colors to test
-            arr[0][5] = Color.Purple;
-            arr[2][3] = Color.Pink;
-            arr[4][0] = Color.Blue;
-
-            var grid = new Custom(arr);
-
-            for (var row = 0; row < Constants.MaxRows; row++)
-            {
-                for (var col = 0; col < Constants.MaxColumns; col++)
-                    Assert.That(grid[row, col], Is.EqualTo(arr[row][col]));
-            }
-        }
-
-        [Test]
-        public void ShouldSetProperColorsWith1DCtor()
-        {
-            var arr = new Color[Constants.MaxKeys];
-
-            arr[5] = Color.Pink;
-            arr[10] = Color.Red;
-            arr[25] = Color.Blue;
-
-            var grid = new Custom(arr);
-
-            for (var index = 0; index < Constants.MaxKeys; index++)
-                Assert.That(grid[index], Is.EqualTo(arr[index]));
         }
 
         [Test]
@@ -438,8 +356,6 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
 
             Assert.False(grid == null);
             Assert.True(grid != null);
-            Assert.False(grid.Equals((Color[][])null));
-            Assert.False(grid.Equals((Color[])null));
             Assert.AreNotEqual(grid, null);
         }
 

--- a/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
+++ b/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
@@ -230,26 +230,6 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
         }
 
         [Test]
-        public void ShouldEqualIdentical2DArray()
-        {
-            var grid = new Custom(Color.Red);
-            var arr = new Color[Constants.MaxRows][];
-
-            // Populate the 2D array
-            for (var row = 0; row < Constants.MaxRows; row++)
-            {
-                arr[row] = new Color[Constants.MaxColumns];
-                for (var col = 0; col < Constants.MaxColumns; col++)
-                    arr[row][col] = Color.Red;
-            }
-
-            Assert.True(grid == arr);
-            Assert.False(grid != arr);
-            Assert.True(grid.Equals(arr));
-            Assert.AreEqual(grid, arr);
-        }
-
-        [Test]
         public void ShouldNotEqualDifferent2DArray()
         {
             var grid = new Custom(Color.Pink);
@@ -287,49 +267,6 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
             var grid = Custom.Create();
             var arr = new Color[Constants.MaxRows][];
             arr[0] = new Color[2];
-
-            Assert.False(grid == arr);
-            Assert.True(grid != arr);
-            Assert.False(grid.Equals(arr));
-            Assert.AreNotEqual(grid, arr);
-        }
-
-        [Test]
-        public void ShouldEqualIdentical1DArray()
-        {
-            var grid = new Custom(Color.Red);
-            var arr = new Color[Constants.MaxKeys];
-
-            // Populate the 1D array
-            for (var index = 0; index < Constants.MaxKeys; index++)
-                arr[index] = Color.Red;
-
-            Assert.True(grid == arr);
-            Assert.False(grid != arr);
-            Assert.True(grid.Equals(arr));
-            Assert.AreEqual(grid, arr);
-        }
-
-        [Test]
-        public void ShouldNotEqualDifferent1DArray()
-        {
-            var grid = new Custom(Color.Pink);
-            var arr = new Color[Constants.MaxKeys];
-
-            for (var index = 0; index < Constants.MaxKeys; index++)
-                arr[index] = Color.Red;
-
-            Assert.False(grid == arr);
-            Assert.True(grid != arr);
-            Assert.False(grid.Equals(arr));
-            Assert.AreNotEqual(grid, arr);
-        }
-
-        [Test]
-        public void ShouldNotEqual1DArrayWithInvalidSize()
-        {
-            var grid = Custom.Create();
-            var arr = new Color[2];
 
             Assert.False(grid == arr);
             Assert.True(grid != arr);
@@ -376,7 +313,8 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
         [Test]
         public void ShouldGetWithKeyIndexer()
         {
-            var grid = new Custom(Color.Red);
+            var grid = Custom.Create();
+            grid[Key.Escape] = Color.Red;
             Assert.AreEqual(Color.Red, grid[Key.Escape]);
         }
 

--- a/Corale.Colore.ruleset
+++ b/Corale.Colore.ruleset
@@ -72,7 +72,7 @@
     <Rule Id="SA1117" Action="None" />
     <Rule Id="SA1127" Action="None" />
     <Rule Id="SA1309" Action="None" />
-    <Rule Id="SA1407" Action="Info" />
+    <Rule Id="SA1407" Action="None" />
     <Rule Id="SA1503" Action="None" />
     <Rule Id="SA1520" Action="None" />
   </Rules>

--- a/Corale.Colore.sln.DotSettings
+++ b/Corale.Colore.sln.DotSettings
@@ -18,6 +18,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_WHILE_BRACES_STYLE/@EntryValue">ONLY_FOR_MULTILINE</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/LINE_FEED_AT_FILE_END/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SIMPLE_EMBEDDED_STATEMENT_STYLE/@EntryValue">LINE_BREAK</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AROUND_MULTIPLICATIVE_OP/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARRAY_INITIALIZER_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
 	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;

--- a/Corale.Colore.sln.DotSettings
+++ b/Corale.Colore.sln.DotSettings
@@ -18,6 +18,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/FORCE_WHILE_BRACES_STYLE/@EntryValue">ONLY_FOR_MULTILINE</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/LINE_FEED_AT_FILE_END/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SIMPLE_EMBEDDED_STATEMENT_STYLE/@EntryValue">LINE_BREAK</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AROUND_MULTIPLICATIVE_OP/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARRAY_INITIALIZER_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
 	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;
 &lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;

--- a/Corale.Colore.sln.DotSettings
+++ b/Corale.Colore.sln.DotSettings
@@ -259,6 +259,7 @@
 &lt;/copyright&gt;&#xD;
 ---------------------------------------------------------------------------------------&#xD;
 </s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=LocalConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>

--- a/Corale.Colore/Core/Color.cs
+++ b/Corale.Colore/Core/Color.cs
@@ -40,105 +40,86 @@ namespace Corale.Colore.Core
     public partial struct Color : IEquatable<Color>, IEquatable<uint>, IEquatable<SystemColor>, IEquatable<WpfColor>
     {
         /// <summary>
-        /// Internal color value.
-        /// </summary>
-        /// <remarks>
-        /// Format: <c>0xAABBGGRR</c>.
-        /// </remarks>
-        private readonly uint _value;
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="Color" /> struct using an integer
-        /// color value in the format <c>0xAABBGGRR</c>. Where the alpha component ranges
-        /// from <c>0x00</c> (fully transparent) to <c>0xFF</c> (fully opaque).
+        /// color value in the format <c>0xKKBBGGRR</c>.
         /// </summary>
         /// <param name="value">Value to create the color from.</param>
         [PublicAPI]
         public Color(uint value)
         {
-            _value = value;
+            Value = value;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Color" /> struct using three
-        /// distinct R, G, B, and A (optional) byte values. An alpha value of <c>0</c>
-        /// is treated as fully opaque.
+        /// distinct R, G, and B byte values.
         /// </summary>
         /// <param name="red">The red component.</param>
         /// <param name="green">The green component.</param>
         /// <param name="blue">The blue component.</param>
-        /// <param name="alpha">The alpha component (<c>0</c> = fully opaque).</param>
         [PublicAPI]
-        public Color(byte red, byte green, byte blue, byte alpha = 255)
-            : this(red + ((uint)green << 8) + ((uint)blue << 16) + ((uint)alpha << 24))
+        public Color(byte red, byte green, byte blue)
+            : this(red + ((uint)green << 8) + ((uint)blue << 16))
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Color" /> struct using
         /// three <see cref="float" /> (<c>float</c>) values for the
-        /// R, G, B, and A (optional) channels.
+        /// R, G, and B channels.
         /// </summary>
         /// <param name="red">The red component (<c>0.0f</c> to <c>1.0f</c>, inclusive).</param>
         /// <param name="green">The green component (<c>0.0f</c> to <c>1.0f</c>, inclusive).</param>
         /// <param name="blue">The blue component (<c>0.0f</c> to <c>1.0f</c>, inclusive).</param>
-        /// <param name="alpha">The alpha component (<c>0.0f</c> to <c>1.0f</c>, inclusive, <c>0.0f</c> = fully opaque).</param>
         /// <remarks>
         /// Each parameter value must be between <c>0.0f</c> and <c>1.0f</c> (inclusive).
         /// </remarks>
         [PublicAPI]
-        public Color(float red, float green, float blue, float alpha = 1.0f)
-            : this((byte)(red * 255), (byte)(green * 255), (byte)(blue * 255), (byte)(alpha * 255))
+        public Color(float red, float green, float blue)
+            : this((byte)(red * 255), (byte)(green * 255), (byte)(blue * 255))
         {
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Color" /> struct using
-        /// three <see cref="double" /> values for the R, G, B, and A (optional) channels.
+        /// three <see cref="double" /> values for the R, G, and B channels.
         /// </summary>
         /// <param name="red">The red component (<c>0.0</c> to <c>1.0</c>, inclusive).</param>
         /// <param name="green">The green component (<c>0.0</c> to <c>1.0</c>, inclusive).</param>
         /// <param name="blue">The blue component (<c>0.0</c> to <c>1.0</c>, inclusive).</param>
-        /// <param name="alpha">The alpha component (<c>0.0</c> to <c>1.0</c>, inclusive, <c>0.0</c> = fully opaque).</param>
         /// <remarks>
         /// Each parameter value must be between <c>0.0</c> and <c>1.0</c> (inclusive).
         /// </remarks>
         [PublicAPI]
-        public Color(double red, double green, double blue, double alpha = 1.0)
-            : this((byte)(red * 255), (byte)(green * 255), (byte)(blue * 255), (byte)(alpha * 255))
+        public Color(double red, double green, double blue)
+            : this((byte)(red * 255), (byte)(green * 255), (byte)(blue * 255))
         {
         }
-
-        /// <summary>
-        /// Gets the alpha component of the color as a byte.
-        /// </summary>
-        [PublicAPI]
-        public byte A => (byte)((_value >> 24) & 0xFF);
 
         /// <summary>
         /// Gets the blue component of the color as a byte.
         /// </summary>
         [PublicAPI]
-        public byte B => (byte)((_value >> 16) & 0xFF);
+        public byte B => (byte)((Value >> 16) & 0xFF);
 
         /// <summary>
         /// Gets the green component of the color as a byte.
         /// </summary>
         [PublicAPI]
-        public byte G => (byte)((_value >> 8) & 0xFF);
+        public byte G => (byte)((Value >> 8) & 0xFF);
 
         /// <summary>
         /// Gets the red component of the color as a byte.
         /// </summary>
         [PublicAPI]
-        public byte R => (byte)(_value & 0xFF);
+        public byte R => (byte)(Value & 0xFF);
 
         /// <summary>
         /// Gets the unsigned integer representing
-        /// the color. On the form <c>0xAABBGGRR</c>.
+        /// the color. On the form <c>0xKKBBGGRR</c>.
         /// </summary>
         [PublicAPI]
-        public uint Value => _value;
+        public uint Value { get; }
 
         /// <summary>
         /// Converts a <see cref="Color" /> struct to a <see cref="uint" />.
@@ -148,7 +129,7 @@ namespace Corale.Colore.Core
         /// <remarks>The returned <see cref="uint" /> has a format of <c>0xAABBGGRR</c>.</remarks>
         public static implicit operator uint(Color color)
         {
-            return color._value;
+            return color.Value;
         }
 
         /// <summary>
@@ -172,7 +153,7 @@ namespace Corale.Colore.Core
         /// </returns>
         public static implicit operator SystemColor(Color color)
         {
-            return SystemColor.FromArgb(color.A, color.R, color.G, color.B);
+            return SystemColor.FromArgb(color.R, color.G, color.B);
         }
 
         /// <summary>
@@ -197,7 +178,7 @@ namespace Corale.Colore.Core
         /// </returns>
         public static implicit operator WpfColor(Color color)
         {
-            return WpfColor.FromArgb(color.A, color.R, color.G, color.B);
+            return WpfColor.FromRgb(color.R, color.G, color.B);
         }
 
         /// <summary>
@@ -243,7 +224,7 @@ namespace Corale.Colore.Core
         [PublicAPI]
         public static Color FromSystemColor(SystemColor source)
         {
-            return new Color(source.R, source.G, source.B, source.A);
+            return new Color(source.R, source.G, source.B);
         }
 
         /// <summary>
@@ -255,21 +236,7 @@ namespace Corale.Colore.Core
         [PublicAPI]
         public static Color FromWpfColor(WpfColor source)
         {
-            return new Color(source.R, source.G, source.B, source.A);
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="Color" /> from an ARGB integer value
-        /// in the format of <c>0xAARRGGBB</c> where the alpha component
-        /// ranges from <c>0x00</c> (fully transparent) to <c>0xFF</c> (fully opaque).
-        /// </summary>
-        /// <param name="value">The ARGB value to convert from.</param>
-        /// <returns>A new instance of the <see cref="Color" /> struct.</returns>
-        [PublicAPI]
-        public static Color FromArgb(uint value)
-        {
-            var abgr = (value & 0xFF00FF00) | ((value & 0xFF0000) >> 16) | ((value & 0xFF) << 16);
-            return new Color(abgr);
+            return new Color(source.R, source.G, source.B);
         }
 
         /// <summary>
@@ -281,8 +248,7 @@ namespace Corale.Colore.Core
         [PublicAPI]
         public static Color FromRgb(uint value)
         {
-            var abgr = 0xFF000000 | ((value & 0xFF0000) >> 16) | (value & 0xFF00) | ((value & 0xFF) << 16);
-            return new Color(abgr);
+            return new Color(((value & 0xFF0000) >> 16) | (value & 0xFF00) | ((value & 0xFF) << 16));
         }
 
         /// <summary>
@@ -317,9 +283,13 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="other">The <see cref="Color" /> to check equality against.</param>
         /// <returns><c>true</c> of the two are equal, false otherwise.</returns>
+        /// <remarks>
+        /// Only compares the lower 32 bits of each color value, in order to
+        /// be able to compare a keymode color to a non-keymode color.
+        /// </remarks>
         public bool Equals(Color other)
         {
-            return _value.Equals(other._value);
+            return Value.Equals(other.Value);
         }
 
         /// <summary>
@@ -328,9 +298,13 @@ namespace Corale.Colore.Core
         /// </summary>
         /// <param name="other">The <see cref="uint" /> to check equality against.</param>
         /// <returns><c>true</c> if the two are equal, <c>false</c> otherwise.</returns>
+        /// <remarks>
+        /// Only compares the lower 32 bits of each value, in order to
+        /// be able to compare a keymode color to a non-keymode color.
+        /// </remarks>
         public bool Equals(uint other)
         {
-            return _value.Equals(other);
+            return Value.Equals(other);
         }
 
         /// <summary>
@@ -343,7 +317,7 @@ namespace Corale.Colore.Core
         /// <param name="other">An instance of <see cref="System.Drawing.Color" /> to compare with this object.</param>
         public bool Equals(SystemColor other)
         {
-            return R == other.R && G == other.G && B == other.B && A == other.A;
+            return R == other.R && G == other.G && B == other.B;
         }
 
         /// <summary>
@@ -354,7 +328,7 @@ namespace Corale.Colore.Core
         /// <returns><c>true</c> if the current object is equal to the <paramref name="other" /> parameter; otherwise, <c>false</c>.</returns>
         public bool Equals(WpfColor other)
         {
-            return R == other.R && G == other.G && B == other.B & A == other.A;
+            return R == other.R && G == other.G && B == other.B;
         }
 
         /// <summary>
@@ -363,7 +337,7 @@ namespace Corale.Colore.Core
         /// <returns>A unique has code.</returns>
         public override int GetHashCode()
         {
-            return (int)_value;
+            return (int)Value;
         }
     }
 }

--- a/Corale.Colore/Core/IKeyboard.cs
+++ b/Corale.Colore/Core/IKeyboard.cs
@@ -38,6 +38,7 @@ namespace Corale.Colore.Core
     {
         /// <summary>
         /// Gets or sets the <see cref="Color" /> for a specific <see cref="Key" /> on the keyboard.
+        /// The SDK will translate this appropriately depending on user configuration.
         /// </summary>
         /// <param name="key">The key to access.</param>
         /// <returns>The color currently set for the specified key.</returns>
@@ -93,21 +94,6 @@ namespace Corale.Colore.Core
         /// <param name="duration">How long to illuminate the key after being pressed.</param>
         [PublicAPI]
         void SetReactive(Color color, Duration duration);
-
-        /// <summary>
-        /// Sets a custom grid effect on the keyboard using
-        /// a two dimensional array of color values.
-        /// </summary>
-        /// <param name="colors">The grid of colors to use.</param>
-        /// <remarks>
-        /// The passed in arrays cannot have more than <see cref="Constants.MaxRows" /> rows and
-        /// not more than <see cref="Constants.MaxColumns" /> columns in any row.
-        /// <para />
-        /// This will overwrite the internal <see cref="Custom" />
-        /// struct in the <see cref="Keyboard" /> class.
-        /// </remarks>
-        [PublicAPI]
-        void SetGrid(Color[][] colors);
 
         /// <summary>
         /// Sets a custom grid effect on the keyboard.

--- a/Corale.Colore/Core/Keyboard.cs
+++ b/Corale.Colore/Core/Keyboard.cs
@@ -73,13 +73,8 @@ namespace Corale.Colore.Core
             CurrentEffectId = Guid.Empty;
 
             // We keep a local copy of a grid to speed up grid operations
-            Log.Debug("Creating grid array");
-            var gridArray = new Color[Constants.MaxRows][];
-            for (var i = 0; i < Constants.MaxRows; i++)
-                gridArray[i] = new Color[Constants.MaxColumns];
-
             Log.Debug("Initializing private copy of Custom");
-            _grid = new Custom(gridArray);
+            _grid = Custom.Create();
         }
 
         /// <summary>
@@ -99,6 +94,7 @@ namespace Corale.Colore.Core
 
         /// <summary>
         /// Gets or sets the <see cref="Color" /> for a specific <see cref="Key" /> on the keyboard.
+        /// The SDK will translate this appropriately depending on user configuration.
         /// </summary>
         /// <param name="key">The key to access.</param>
         /// <returns>The color currently set for the specified key.</returns>
@@ -228,23 +224,6 @@ namespace Corale.Colore.Core
         public void SetReactive(Color color, Duration duration)
         {
             SetReactive(new Reactive(color, duration));
-        }
-
-        /// <summary>
-        /// Sets a custom grid effect on the keyboard using
-        /// a two dimensional array of color values.
-        /// </summary>
-        /// <param name="colors">The grid of colors to use.</param>
-        /// <remarks>
-        /// The passed in arrays cannot have more than <see cref="Constants.MaxRows" /> rows and
-        /// not more than <see cref="Constants.MaxColumns" /> columns in any row.
-        /// <para />
-        /// This will overwrite the internal <see cref="Custom" />
-        /// struct in the <see cref="Keyboard" /> class.
-        /// </remarks>
-        public void SetGrid(Color[][] colors)
-        {
-            SetCustom(new Custom(colors));
         }
 
         /// <summary>

--- a/Corale.Colore/Core/Keyboard.cs
+++ b/Corale.Colore/Core/Keyboard.cs
@@ -192,7 +192,7 @@ namespace Corale.Colore.Core
         public override void SetAll(Color color)
         {
             _grid.Set(color);
-            SetGuid(NativeWrapper.CreateKeyboardEffect(Effect.Custom, _grid));
+            SetGuid(NativeWrapper.CreateKeyboardEffect(Effect.CustomKey, _grid));
         }
 
         /// <summary>
@@ -237,7 +237,7 @@ namespace Corale.Colore.Core
         public void SetCustom(Custom effect)
         {
             _grid = effect;
-            SetGuid(NativeWrapper.CreateKeyboardEffect(Effect.Custom, _grid));
+            SetGuid(NativeWrapper.CreateKeyboardEffect(Effect.CustomKey, _grid));
         }
 
         /// <summary>
@@ -273,7 +273,7 @@ namespace Corale.Colore.Core
                 _grid.Clear();
 
             _grid[row, column] = color;
-            SetGuid(NativeWrapper.CreateKeyboardEffect(Effect.Custom, _grid));
+            SetGuid(NativeWrapper.CreateKeyboardEffect(Effect.CustomKey, _grid));
         }
 
         /// <summary>
@@ -288,7 +288,7 @@ namespace Corale.Colore.Core
                 _grid.Clear();
 
             _grid[key] = color;
-            SetGuid(NativeWrapper.CreateKeyboardEffect(Effect.Custom, _grid));
+            SetGuid(NativeWrapper.CreateKeyboardEffect(Effect.CustomKey, _grid));
         }
 
         /// <summary>

--- a/Corale.Colore/Razer/Keyboard/Constants.cs
+++ b/Corale.Colore/Razer/Keyboard/Constants.cs
@@ -55,5 +55,10 @@ namespace Corale.Colore.Razer.Keyboard
         /// </summary>
         [PublicAPI]
         public const int MaxCustomEffects = MaxKeys;
+
+        /// <summary>
+        /// The bit that needs to be set for key mode to be active on a color.
+        /// </summary>
+        internal const int KeyFlag = 0x01000000;
     }
 }

--- a/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
@@ -202,16 +202,12 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         {
             get
             {
-                var row = (int)key >> 8;
-                var column = (int)key & 0xFF;
-                return this[row, column];
+                return _keys[(int)key];
             }
 
             set
             {
-                var row = (int)key >> 8;
-                var column = (int)key & 0xFF;
-                this[row, column] = Constants.KeyFlag | value;
+                _keys[(int)key] = Constants.KeyFlag | value;
             }
         }
 

--- a/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
@@ -202,12 +202,16 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         {
             get
             {
-                return _keys[(int)key];
+                var index = (int)key;
+                index = (index >> 8) * Constants.MaxColumns + (index & 0xFF);
+                return _keys[index];
             }
 
             set
             {
-                _keys[(int)key] = Constants.KeyFlag | value;
+                var index = (int)key;
+                index = (index >> 8) * Constants.MaxColumns + (index & 0xFF);
+                _keys[index] = Constants.KeyFlag | value;
             }
         }
 

--- a/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
@@ -200,7 +200,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
             {
                 var index = (int)key;
                 index = (index >> 8) * Constants.MaxColumns + (index & 0xFF);
-                return _keys[index];
+                return _keys[index] & 0xFFFFFF;
             }
 
             set

--- a/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
@@ -85,8 +85,8 @@ namespace Corale.Colore.Razer.Keyboard.Effects
 
             for (var index = 0; index < Constants.MaxKeys; index++)
             {
-                this[(Key)index] = other[(Key)index];
-                this[index] = other[index];
+                _colors[index] = other[index];
+                _keys[index] = other[(Key)index];
             }
         }
 

--- a/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
@@ -117,9 +117,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
                         "Attempted to access a column that does not exist.");
                 }
 
-#pragma warning disable SA1407 // Arithmetic expressions must declare precedence
                 return _colors[column + row * Constants.MaxColumns];
-#pragma warning restore SA1407 // Arithmetic expressions must declare precedence
             }
 
             set
@@ -140,9 +138,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
                         "Attempted to access a column that does not exist.");
                 }
 
-#pragma warning disable SA1407 // Arithmetic expressions must declare precedence
                 var index = column + row * Constants.MaxColumns;
-#pragma warning restore SA1407 // Arithmetic expressions must declare precedence
 
                 _keys[index] = _keys[index] & 0xFFFFFF;
                 _colors[index] = value;

--- a/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
@@ -70,10 +70,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
             _keys = new Color[Constants.MaxKeys];
 
             for (var index = 0; index < Constants.MaxKeys; index++)
-            {
-                this[(Key)index] = color;
                 this[index] = color;
-            }
         }
 
         /// <summary>

--- a/Corale.Colore/Razer/Keyboard/Effects/Effect.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Effect.cs
@@ -82,6 +82,12 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         Starlight,
 
         /// <summary>
+        /// Custom effect with keys.
+        /// </summary>
+        [PublicAPI]
+        CustomKey,
+
+        /// <summary>
         /// Invalid effect.
         /// </summary>
         [PublicAPI]


### PR DESCRIPTION
This will update keyboard's `Custom` effect to support the new layout-agnostic (at least, it's supposed to be, see #168) grid system.

CI has been updated to support `feature/separate-integrations` so test runs from this branch will fail. It's been tested locally with every test passing so merging should be fine if the rest of the code looks good.