### PR TITLE
Implement new system effects

### DIFF
--- a/Corale.Colore.Tests/Corale.Colore.Tests.csproj
+++ b/Corale.Colore.Tests/Corale.Colore.Tests.csproj
@@ -98,6 +98,15 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Core\ColorTests.cs" />
     <Compile Include="Razer\DevicesTests.cs" />
+    <Compile Include="Razer\Effects\BlinkingTests.cs" />
+    <Compile Include="Razer\Effects\BreathingTests.cs" />
+    <Compile Include="Razer\Effects\CustomTests.cs" />
+    <Compile Include="Razer\Effects\NoneTests.cs" />
+    <Compile Include="Razer\Effects\ReactiveTests.cs" />
+    <Compile Include="Razer\Effects\SpectrumCyclingTests.cs" />
+    <Compile Include="Razer\Effects\StarlightTests.cs" />
+    <Compile Include="Razer\Effects\StaticTests.cs" />
+    <Compile Include="Razer\Effects\WaveTests.cs" />
     <Compile Include="Razer\Headset\Effects\BreathingTests.cs" />
     <Compile Include="Razer\Headset\Effects\StaticTests.cs" />
     <Compile Include="Razer\Keyboard\Effects\BreathingTests.cs" />
@@ -146,6 +155,7 @@
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Corale.Colore.Tests/Razer/Effects/BlinkingTests.cs
+++ b/Corale.Colore.Tests/Razer/Effects/BlinkingTests.cs
@@ -1,0 +1,46 @@
+﻿// <copyright file="BlinkingTests.cs" company="Corale">
+//     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+
+namespace Corale.Colore.Tests.Razer.Effects
+{
+    using Corale.Colore.Core;
+    using Corale.Colore.Razer.Effects;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class BlinkingTests
+    {
+        [Test]
+        public void ShouldConstructWithCorrectColor()
+        {
+            Assert.That(new Blinking(Color.Red).Color, Is.EqualTo(Color.Red));
+        }
+
+        [Test]
+        public void ShouldConstructWithCorrectParameter()
+        {
+            Assert.That(new Blinking(Color.Black, 42).Parameter, Is.EqualTo(42));
+        }
+    }
+}

--- a/Corale.Colore.Tests/Razer/Effects/BreathingTests.cs
+++ b/Corale.Colore.Tests/Razer/Effects/BreathingTests.cs
@@ -1,0 +1,76 @@
+﻿// <copyright file="BreathingTests.cs" company="Corale">
+//     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+
+namespace Corale.Colore.Tests.Razer.Effects
+{
+    using Corale.Colore.Core;
+    using Corale.Colore.Razer.Effects;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class BreathingTests
+    {
+        [Test]
+        public void ShouldConstructWithCorrectParameter()
+        {
+            Assert.That(new Breathing(42).Parameter, Is.EqualTo(42));
+        }
+
+        [Test]
+        public void ShouldConstructWithCorrectType()
+        {
+            Assert.That(new Breathing(BreathingType.One, Color.Black, Color.Black).Type, Is.EqualTo(BreathingType.One));
+        }
+
+        [Test]
+        public void ShouldConstructWithCorrectFirstColor()
+        {
+            Assert.That(new Breathing(BreathingType.Two, Color.Red, Color.Blue).First, Is.EqualTo(Color.Red));
+        }
+
+        [Test]
+        public void ShouldConstructWithCorrectSecondColor()
+        {
+            Assert.That(new Breathing(BreathingType.Two, Color.Red, Color.Blue).Second, Is.EqualTo(Color.Blue));
+        }
+
+        [Test]
+        public void ShouldUseRandomTypeWithNoColors()
+        {
+            Assert.That(Breathing.Create().Type, Is.EqualTo(BreathingType.Random));
+        }
+
+        [Test]
+        public void ShouldUseOneTypeWithOneColor()
+        {
+            Assert.That(new Breathing(Color.Red).Type, Is.EqualTo(BreathingType.One));
+        }
+
+        [Test]
+        public void ShouldUseTwoTypeWithTwoColors()
+        {
+            Assert.That(new Breathing(Color.Red, Color.Blue).Type, Is.EqualTo(BreathingType.Two));
+        }
+    }
+}

--- a/Corale.Colore.Tests/Razer/Effects/CustomTests.cs
+++ b/Corale.Colore.Tests/Razer/Effects/CustomTests.cs
@@ -1,0 +1,392 @@
+﻿// <copyright file="CustomTests.cs" company="Corale">
+//     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+
+namespace Corale.Colore.Tests.Razer.Effects
+{
+    using System;
+
+    using Corale.Colore.Core;
+    using Corale.Colore.Razer;
+    using Corale.Colore.Razer.Effects;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class CustomTests
+    {
+        [Test]
+        public void ShouldThrowWhenOutOfRange2DGet()
+        {
+            var grid = Custom.Create();
+
+            // ReSharper disable once NotAccessedVariable
+            Color dummy;
+
+            Assert.That(
+                () => dummy = grid[-1, 0],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("row")
+                      .And.Property("ActualValue")
+                      .EqualTo(-1));
+
+            Assert.That(
+                () => dummy = grid[Constants.MaxRows, 0],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("row")
+                      .And.Property("ActualValue")
+                      .EqualTo(Constants.MaxRows));
+
+            Assert.That(
+                () => dummy = grid[0, -1],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("column")
+                      .And.Property("ActualValue")
+                      .EqualTo(-1));
+
+            Assert.That(
+                () => dummy = grid[0, Constants.MaxColumns],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("column")
+                      .And.Property("ActualValue")
+                      .EqualTo(Constants.MaxColumns));
+        }
+
+        [Test]
+        public void ShouldThrowWhenOutOfRange2DSet()
+        {
+            var grid = Custom.Create();
+
+            Assert.That(
+                () => grid[-1, 0] = Color.Red,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("row")
+                      .And.Property("ActualValue")
+                      .EqualTo(-1));
+
+            Assert.That(
+                () => grid[Constants.MaxRows, 0] = Color.Red,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("row")
+                      .And.Property("ActualValue")
+                      .EqualTo(Constants.MaxRows));
+
+            Assert.That(
+                () => grid[0, -1] = Color.Red,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("column")
+                      .And.Property("ActualValue")
+                      .EqualTo(-1));
+
+            Assert.That(
+                () => grid[0, Constants.MaxColumns] = Color.Red,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("column")
+                      .And.Property("ActualValue")
+                      .EqualTo(Constants.MaxColumns));
+        }
+
+        [Test]
+        public void ShouldThrowWhenOutOfRange1DGet()
+        {
+            var grid = Custom.Create();
+
+            // ReSharper disable once NotAccessedVariable
+            Color dummy;
+
+            Assert.That(
+                () => dummy = grid[-1],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("index")
+                      .And.Property("ActualValue")
+                      .EqualTo(-1));
+
+            Assert.That(
+                () => dummy = grid[Constants.MaxColors],
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("index")
+                      .And.Property("ActualValue")
+                      .EqualTo(Constants.MaxColors));
+        }
+
+        [Test]
+        public void ShouldThrowWhenOutOfRange1DSet()
+        {
+            var grid = Custom.Create();
+
+            Assert.That(
+                () => grid[-1] = Color.Red,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("index")
+                      .And.Property("ActualValue")
+                      .EqualTo(-1));
+
+            Assert.That(
+                () => grid[Constants.MaxColors] = Color.Red,
+                Throws.InstanceOf<ArgumentOutOfRangeException>()
+                      .With.Property("ParamName")
+                      .EqualTo("index")
+                      .And.Property("ActualValue")
+                      .EqualTo(Constants.MaxColors));
+        }
+
+        [Test]
+        public void ShouldThrowWhenInvalid2DRowCount()
+        {
+            var arr = new Color[2, Constants.MaxColumns];
+
+            // ReSharper disable once NotAccessedVariable
+            Custom dummy;
+
+            Assert.That(
+                () => dummy = new Custom(arr),
+                Throws.ArgumentException.With.Property("ParamName").EqualTo("colors"));
+        }
+
+        [Test]
+        public void ShouldThrowWhenInvalid2DColumnCount()
+        {
+            var arr = new Color[Constants.MaxRows, 2];
+
+            // ReSharper disable once NotAccessedVariable
+            Custom dummy;
+
+            Assert.That(
+                () => dummy = new Custom(arr),
+                Throws.ArgumentException.With.Property("ParamName").EqualTo("colors"));
+        }
+
+        [Test]
+        public void ShouldThrowWhenInvalid1DSize()
+        {
+            var arr = new Color[2];
+
+            // ReSharper disable once NotAccessedVariable
+            Custom dummy;
+
+            Assert.That(
+                () => dummy = new Custom(arr),
+                Throws.ArgumentException.With.Property("ParamName").EqualTo("colors"));
+        }
+
+        [Test]
+        public void ShouldSetToBlackWithCreate()
+        {
+            var grid = Custom.Create();
+
+            for (var row = 0; row < Constants.MaxRows; row++)
+            {
+                for (var column = 0; column < Constants.MaxColumns; column++)
+                    Assert.That(grid[row, column], Is.EqualTo(Color.Black));
+            }
+        }
+
+        [Test]
+        public void ShouldSetAllColorsWithColorCtor()
+        {
+            var grid = new Custom(Color.Red);
+
+            for (var row = 0; row < Constants.MaxRows; row++)
+            {
+                for (var column = 0; column < Constants.MaxColumns; column++)
+                    Assert.That(grid[row, column], Is.EqualTo(Color.Red));
+            }
+        }
+
+        [Test]
+        public void ShouldSetProperColorsWith2DCtor()
+        {
+            var arr = new Color[Constants.MaxRows, Constants.MaxColumns];
+
+            // Set some arbitrary colors to test
+            arr[0, 4] = Color.Purple;
+            arr[2, 3] = Color.Pink;
+            arr[3, 0] = Color.Blue;
+
+            var grid = new Custom(arr);
+
+            for (var row = 0; row < Constants.MaxRows; row++)
+            {
+                for (var col = 0; col < Constants.MaxColumns; col++)
+                    Assert.That(grid[row, col], Is.EqualTo(arr[row, col]));
+            }
+        }
+
+        [Test]
+        public void ShouldSetProperColorsWith1DCtor()
+        {
+            var arr = new Color[Constants.MaxColors];
+
+            arr[2] = Color.Pink;
+            arr[4] = Color.Red;
+            arr[8] = Color.Blue;
+
+            var grid = new Custom(arr);
+
+            for (var index = 0; index < Constants.MaxColors; index++)
+                Assert.That(grid[index], Is.EqualTo(arr[index]));
+        }
+
+        [Test]
+        public void ShouldSetNewColors()
+        {
+            var grid = Custom.Create();
+
+            grid[0, 4] = Color.Red;
+
+            Assert.That(grid[0, 4], Is.EqualTo(Color.Red));
+        }
+
+        [Test]
+        public void ShouldClearToBlack()
+        {
+            var grid = new Custom(Color.Pink);
+            grid.Clear();
+
+            Assert.That(grid, Is.EqualTo(Custom.Create()));
+        }
+
+        [Test]
+        public void ShouldSetColorsProperly()
+        {
+            var grid = Custom.Create();
+            grid.Set(Color.Red);
+
+            for (var row = 0; row < Constants.MaxRows; row++)
+            {
+                for (var column = 0; column < Constants.MaxColumns; column++)
+                    Assert.AreEqual(Color.Red, grid[row, column]);
+            }
+        }
+
+        [Test]
+        public void ShouldEqualIdenticalGrid()
+        {
+            var a = new Custom(Color.Red, 42);
+            var b = new Custom(Color.Red, 42);
+
+            Assert.True(a == b);
+            Assert.False(a != b);
+            Assert.True(a.Equals(b));
+            Assert.AreEqual(a, b);
+        }
+
+        [Test]
+        public void ShouldNotEqualDifferentGrid()
+        {
+            var a = new Custom(Color.Red, 42);
+            var b = new Custom(Color.Pink, 666);
+
+            Assert.False(a == b);
+            Assert.True(a != b);
+            Assert.False(a.Equals(b));
+            Assert.AreNotEqual(a, b);
+        }
+
+        [Test]
+        public void ShouldNotEqualArbitraryObject()
+        {
+            var grid = Custom.Create();
+            var obj = new object();
+
+            Assert.False(grid == obj);
+            Assert.True(grid != obj);
+            Assert.False(grid.Equals(obj));
+            Assert.AreNotEqual(grid, obj);
+        }
+
+        [Test]
+        public void ShouldNotEqualNull()
+        {
+            var grid = Custom.Create();
+
+            Assert.False(grid == null);
+            Assert.True(grid != null);
+            Assert.AreNotEqual(grid, null);
+        }
+
+        [Test]
+        public void ShouldGetWithGridIndexer()
+        {
+            var grid = new Custom(Color.Red);
+            Assert.AreEqual(Color.Red, grid[3, 3]);
+        }
+
+        [Test]
+        public void ShouldGetWithIndexIndexer()
+        {
+            var grid = new Custom(Color.Red);
+            Assert.AreEqual(Color.Red, grid[3]);
+        }
+
+        [Test]
+        public void ShouldSetWithGridIndexer()
+        {
+            var grid = Custom.Create();
+
+            grid[3, 4] = Color.Red;
+
+            Assert.AreEqual(Color.Red, grid[3, 4]);
+        }
+
+        [Test]
+        public void ShouldSetWithIndexIndexer()
+        {
+            var grid = Custom.Create();
+
+            grid[5] = Color.Red;
+
+            Assert.AreEqual(Color.Red, grid[5]);
+        }
+
+        [Test]
+        public void ClonedStructShouldBeIdentical()
+        {
+            var original = new Custom(Color.Red);
+            var clone = original.Clone();
+
+            Assert.That(clone, Is.EqualTo(original));
+        }
+
+        [Test]
+        public void ClonedStructShouldBeIndependent()
+        {
+            var original = new Custom(Color.Red);
+            var clone = original.Clone();
+
+            clone.Set(Color.Blue);
+
+            Assert.That(clone, Is.Not.EqualTo(original));
+        }
+    }
+}

--- a/Corale.Colore.Tests/Razer/Effects/NoneTests.cs
+++ b/Corale.Colore.Tests/Razer/Effects/NoneTests.cs
@@ -1,0 +1,39 @@
+﻿// <copyright file="NoneTests.cs" company="Corale">
+//     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+
+namespace Corale.Colore.Tests.Razer.Effects
+{
+    using Corale.Colore.Razer.Effects;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class NoneTests
+    {
+        [Test]
+        public void ShouldConstructWithCorrectParameter()
+        {
+            Assert.That(new None(42).Parameter, Is.EqualTo(42));
+        }
+    }
+}

--- a/Corale.Colore.Tests/Razer/Effects/ReactiveTests.cs
+++ b/Corale.Colore.Tests/Razer/Effects/ReactiveTests.cs
@@ -1,0 +1,52 @@
+﻿// <copyright file="ReactiveTests.cs" company="Corale">
+//     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+
+namespace Corale.Colore.Tests.Razer.Effects
+{
+    using Corale.Colore.Core;
+    using Corale.Colore.Razer.Effects;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class ReactiveTests
+    {
+        [Test]
+        public void ShouldConstructWithCorrectParameter()
+        {
+            Assert.That(new Reactive(Duration.Short, Color.Black, 42).Parameter, Is.EqualTo(42));
+        }
+
+        [Test]
+        public void ShouldConstructWithCorrectDuration()
+        {
+            Assert.That(new Reactive(Duration.Medium, Color.Black).Duration, Is.EqualTo(Duration.Medium));
+        }
+
+        [Test]
+        public void ShouldConstructWithCorrectColor()
+        {
+            Assert.That(new Reactive(Duration.Long, Color.Red).Color, Is.EqualTo(Color.Red));
+        }
+    }
+}

--- a/Corale.Colore.Tests/Razer/Effects/SpectrumCyclingTests.cs
+++ b/Corale.Colore.Tests/Razer/Effects/SpectrumCyclingTests.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="SpectrumCyclingTests.cs" company="Corale">
+//     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+
+namespace Corale.Colore.Tests.Razer.Effects
+{
+    using Corale.Colore.Razer.Effects;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class SpectrumCyclingTests
+    {
+        [Test]
+        public void ShouldConstructWithCorrectParameter()
+        {
+            Assert.That(new SpectrumCycling(42).Parameter, Is.EqualTo(42));
+        }
+
+        [Test]
+        public void CreateShouldSetDefaultParameter()
+        {
+            Assert.That(SpectrumCycling.Create().Parameter, Is.EqualTo(0));
+        }
+    }
+}

--- a/Corale.Colore.Tests/Razer/Effects/StarlightTests.cs
+++ b/Corale.Colore.Tests/Razer/Effects/StarlightTests.cs
@@ -1,0 +1,86 @@
+﻿// <copyright file="StarlightTests.cs" company="Corale">
+//     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+
+namespace Corale.Colore.Tests.Razer.Effects
+{
+    using Corale.Colore.Core;
+    using Corale.Colore.Razer.Effects;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class StarlightTests
+    {
+        [Test]
+        public void ShouldConstructWithCorrectType()
+        {
+            Assert.That(
+                new Starlight(StarlightType.Two, Duration.Short, Color.Black, Color.Black).Type,
+                Is.EqualTo(StarlightType.Two));
+        }
+
+        [Test]
+        public void ShouldConstructWithCorrectDuration()
+        {
+            Assert.That(
+                new Starlight(StarlightType.Two, Duration.Medium, Color.Black, Color.Black).Duration,
+                Is.EqualTo(Duration.Medium));
+        }
+
+        [Test]
+        public void ShouldConstructWithCorrectFirstColor()
+        {
+            Assert.That(
+                new Starlight(StarlightType.Two, Duration.Short, Color.Red, Color.Blue).First,
+                Is.EqualTo(Color.Red));
+        }
+
+        [Test]
+        public void ShouldConstructWithCorrectSecondColor()
+        {
+            Assert.That(
+                new Starlight(StarlightType.Two, Duration.Short, Color.Red, Color.Blue).Second,
+                Is.EqualTo(Color.Blue));
+        }
+
+        [Test]
+        public void ShouldConstructWithCorrectParameter()
+        {
+            Assert.That(
+                new Starlight(StarlightType.Two, Duration.Short, Color.Black, Color.Black, 42).Parameter,
+                Is.EqualTo(42));
+        }
+
+        [Test]
+        public void ShouldSetTwoTypeWithTwoColors()
+        {
+            Assert.That(new Starlight(Duration.Short, Color.Red, Color.Blue).Type, Is.EqualTo(StarlightType.Two));
+        }
+
+        [Test]
+        public void ShouldSetRandomTypeWithNoColors()
+        {
+            Assert.That(new Starlight(Duration.Short).Type, Is.EqualTo(StarlightType.Random));
+        }
+    }
+}

--- a/Corale.Colore.Tests/Razer/Effects/StaticTests.cs
+++ b/Corale.Colore.Tests/Razer/Effects/StaticTests.cs
@@ -1,0 +1,46 @@
+﻿// <copyright file="StaticTests.cs" company="Corale">
+//     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+
+namespace Corale.Colore.Tests.Razer.Effects
+{
+    using Corale.Colore.Core;
+    using Corale.Colore.Razer.Effects;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class StaticTests
+    {
+        [Test]
+        public void ShouldConstructWithCorrectParameter()
+        {
+            Assert.That(new Static(Color.Black, 42).Parameter, Is.EqualTo(42));
+        }
+
+        [Test]
+        public void ShouldConstructWithCorrectColor()
+        {
+            Assert.That(new Static(Color.Red).Color, Is.EqualTo(Color.Red));
+        }
+    }
+}

--- a/Corale.Colore.Tests/Razer/Effects/WaveTests.cs
+++ b/Corale.Colore.Tests/Razer/Effects/WaveTests.cs
@@ -1,0 +1,45 @@
+﻿// <copyright file="WaveTests.cs" company="Corale">
+//     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+
+namespace Corale.Colore.Tests.Razer.Effects
+{
+    using Corale.Colore.Razer.Effects;
+
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class WaveTests
+    {
+        [Test]
+        public void ShouldConstructWithCorrectParameter()
+        {
+            Assert.That(new Wave(Direction.BackToFront, 42).Parameter, Is.EqualTo(42));
+        }
+
+        [Test]
+        public void ShouldConstructWithCorrectDirection()
+        {
+            Assert.That(new Wave(Direction.LeftToRight).Direction, Is.EqualTo(Direction.LeftToRight));
+        }
+    }
+}

--- a/Corale.Colore/Corale.Colore.csproj
+++ b/Corale.Colore/Corale.Colore.csproj
@@ -132,6 +132,19 @@
     <Compile Include="Razer\Devices.cs" />
     <Compile Include="Razer\DeviceType.cs" />
     <Compile Include="Razer\Effect.cs" />
+    <Compile Include="Razer\Effects\Blinking.cs" />
+    <Compile Include="Razer\Effects\Breathing.cs" />
+    <Compile Include="Razer\Effects\BreathingType.cs" />
+    <Compile Include="Razer\Effects\Custom.cs" />
+    <Compile Include="Razer\Effects\Direction.cs" />
+    <Compile Include="Razer\Effects\Duration.cs" />
+    <Compile Include="Razer\Effects\None.cs" />
+    <Compile Include="Razer\Effects\Reactive.cs" />
+    <Compile Include="Razer\Effects\SpectrumCycling.cs" />
+    <Compile Include="Razer\Effects\Starlight.cs" />
+    <Compile Include="Razer\Effects\StarlightType.cs" />
+    <Compile Include="Razer\Effects\Static.cs" />
+    <Compile Include="Razer\Effects\Wave.cs" />
     <Compile Include="Razer\Headset\Effects\Breathing.cs" />
     <Compile Include="Razer\Headset\Effects\Effect.cs" />
     <Compile Include="Razer\Headset\Effects\Static.cs" />
@@ -207,6 +220,7 @@
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
     <Analyzer Include="..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Corale.Colore/Core/GenericDevice.cs
+++ b/Corale.Colore/Core/GenericDevice.cs
@@ -130,12 +130,55 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Sets a blinking effect on this device.
+        /// </summary>
+        /// <param name="color">Color of the effect.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public void SetBlinking(Color color, int parameter = 0)
+        {
+            SetBlinking(new Blinking(color, parameter));
+        }
+
+        /// <summary>
         /// Sets a breathing effect on this device.
         /// </summary>
         /// <param name="effect">Effect options.</param>
         public void SetBreathing(Breathing effect)
         {
             SetGuid(NativeWrapper.CreateDeviceEffect(DeviceId, Effect.Breathing, effect));
+        }
+
+        /// <summary>
+        /// Sets a breathing effect on this device,
+        /// causing it to breathe between random colors.
+        /// </summary>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public void SetBreathing(int parameter = 0)
+        {
+            SetBreathing(new Breathing(parameter));
+        }
+
+        /// <summary>
+        /// Sets a breathing effect on this device,
+        /// causing it to breathe with a single color.
+        /// </summary>
+        /// <param name="color">The color to breathe with.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public void SetBreathing(Color color, int parameter = 0)
+        {
+            SetBreathing(new Breathing(color, parameter));
+        }
+
+        /// <summary>
+        /// Sets a breathing effect on this device,
+        /// causing it to breathe between two colors.
+        /// </summary>
+        /// <param name="first">The first color to breathe with.</param>
+        /// <param name="second">The second color to breathe with.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public void SetBreathing(Color first, Color second, int parameter = 0)
+        {
+            SetBreathing(new Breathing(first, second, parameter));
         }
 
         /// <summary>
@@ -157,12 +200,32 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Sets a reactive effect on this device.
+        /// </summary>
+        /// <param name="color">Color to react with.</param>
+        /// <param name="duration">How long the reaction effect should stay.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public void SetReactive(Color color, Duration duration, int parameter = 0)
+        {
+            SetReactive(new Reactive(duration, color, parameter));
+        }
+
+        /// <summary>
         /// Sets a spectrum cycling effect on this device.
         /// </summary>
         /// <param name="effect">Effect options.</param>
         public void SetSpectrumCycling(SpectrumCycling effect)
         {
             SetGuid(NativeWrapper.CreateDeviceEffect(DeviceId, Effect.SpectrumCycling, effect));
+        }
+
+        /// <summary>
+        /// Sets a spectrum cycling effect on this device.
+        /// </summary>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public void SetSpectrumCycling(int parameter = 0)
+        {
+            SetSpectrumCycling(new SpectrumCycling(parameter));
         }
 
         /// <summary>
@@ -175,6 +238,28 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Sets a starlight effect on this device, using random colors.
+        /// </summary>
+        /// <param name="duration">Duration of the effect.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public void SetStarlight(Duration duration, int parameter = 0)
+        {
+            SetStarlight(new Starlight(duration, parameter));
+        }
+
+        /// <summary>
+        /// Sets a starlight effect on this device, using specified colors.
+        /// </summary>
+        /// <param name="first">The first color to use.</param>
+        /// <param name="second">The second color to use.</param>
+        /// <param name="duration">Duration of the effect.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public void SetStarlight(Color first, Color second, Duration duration, int parameter = 0)
+        {
+            SetStarlight(new Starlight(duration, first, second, parameter));
+        }
+
+        /// <summary>
         /// Sets a static effect on this device.
         /// </summary>
         /// <param name="effect">Effect options.</param>
@@ -184,12 +269,32 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Sets a static effect on this device.
+        /// </summary>
+        /// <param name="color">Color to set.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public void SetStatic(Color color, int parameter = 0)
+        {
+            SetStatic(new Static(color, parameter));
+        }
+
+        /// <summary>
         /// Sets a wave effect on this device.
         /// </summary>
         /// <param name="effect">Effect options.</param>
         public void SetWave(Wave effect)
         {
             SetGuid(NativeWrapper.CreateDeviceEffect(DeviceId, Effect.Wave, effect));
+        }
+
+        /// <summary>
+        /// Sets a wave effect on this device.
+        /// </summary>
+        /// <param name="direction">Direction of the wave.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public void SetWave(Direction direction, int parameter = 0)
+        {
+            SetWave(new Wave(direction, parameter));
         }
     }
 }

--- a/Corale.Colore/Core/GenericDevice.cs
+++ b/Corale.Colore/Core/GenericDevice.cs
@@ -27,12 +27,11 @@ namespace Corale.Colore.Core
 {
     using System;
     using System.Collections.Generic;
-    using System.Runtime.InteropServices;
-    using System.Security;
 
     using Corale.Colore.Annotations;
     using Corale.Colore.Logging;
     using Corale.Colore.Razer;
+    using Corale.Colore.Razer.Effects;
 
     /// <summary>
     /// A generic device.
@@ -86,22 +85,20 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Clears the current effect on Generic Devices.
+        /// </summary>
+        public override void Clear()
+        {
+            SetGuid(NativeWrapper.CreateDeviceEffect(DeviceId, Effect.None, default(None)));
+        }
+
+        /// <summary>
         /// Sets the color of all components on this device.
         /// </summary>
         /// <param name="color">Color to set.</param>
         public override void SetAll(Color color)
         {
-            var colorPtr = Marshal.AllocHGlobal(Marshal.SizeOf(color));
-            Marshal.StructureToPtr(color, colorPtr, false);
-
-            try
-            {
-                SetEffect(Effect.Static, colorPtr);
-            }
-            finally
-            {
-                Marshal.FreeHGlobal(colorPtr);
-            }
+            SetStatic(new Static(color));
         }
 
         /// <summary>
@@ -124,11 +121,75 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
-        /// Clears the current effect on Generic Devices.
+        /// Sets a blinking effect on this device.
         /// </summary>
-        public override void Clear()
+        /// <param name="effect">Effect options.</param>
+        public void SetBlinking(Blinking effect)
         {
-            SetEffect(Effect.None);
+            SetGuid(NativeWrapper.CreateDeviceEffect(DeviceId, Effect.Blinking, effect));
+        }
+
+        /// <summary>
+        /// Sets a breathing effect on this device.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        public void SetBreathing(Breathing effect)
+        {
+            SetGuid(NativeWrapper.CreateDeviceEffect(DeviceId, Effect.Breathing, effect));
+        }
+
+        /// <summary>
+        /// Sets a custom effect on this device.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        public void SetCustom(Custom effect)
+        {
+            SetGuid(NativeWrapper.CreateDeviceEffect(DeviceId, Effect.Custom, effect));
+        }
+
+        /// <summary>
+        /// Sets a reactive effect on this device.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        public void SetReactive(Reactive effect)
+        {
+            SetGuid(NativeWrapper.CreateDeviceEffect(DeviceId, Effect.Reactive, effect));
+        }
+
+        /// <summary>
+        /// Sets a spectrum cycling effect on this device.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        public void SetSpectrumCycling(SpectrumCycling effect)
+        {
+            SetGuid(NativeWrapper.CreateDeviceEffect(DeviceId, Effect.SpectrumCycling, effect));
+        }
+
+        /// <summary>
+        /// Sets a starlight effect on this device.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        public void SetStarlight(Starlight effect)
+        {
+            SetGuid(NativeWrapper.CreateDeviceEffect(DeviceId, Effect.Starlight, effect));
+        }
+
+        /// <summary>
+        /// Sets a static effect on this device.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        public void SetStatic(Static effect)
+        {
+            SetGuid(NativeWrapper.CreateDeviceEffect(DeviceId, Effect.Static, effect));
+        }
+
+        /// <summary>
+        /// Sets a wave effect on this device.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        public void SetWave(Wave effect)
+        {
+            SetGuid(NativeWrapper.CreateDeviceEffect(DeviceId, Effect.Wave, effect));
         }
     }
 }

--- a/Corale.Colore/Core/IGenericDevice.cs
+++ b/Corale.Colore/Core/IGenericDevice.cs
@@ -65,11 +65,46 @@ namespace Corale.Colore.Core
         void SetBlinking(Blinking effect);
 
         /// <summary>
+        /// Sets a blinking effect on this device.
+        /// </summary>
+        /// <param name="color">Color of the effect.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        [PublicAPI]
+        void SetBlinking(Color color, int parameter = 0);
+
+        /// <summary>
         /// Sets a breathing effect on this device.
         /// </summary>
         /// <param name="effect">Effect options.</param>
         [PublicAPI]
         void SetBreathing(Breathing effect);
+
+        /// <summary>
+        /// Sets a breathing effect on this device,
+        /// causing it to breathe between random colors.
+        /// </summary>
+        /// <param name="parameter">Additional effect parameter.</param>
+        [PublicAPI]
+        void SetBreathing(int parameter = 0);
+
+        /// <summary>
+        /// Sets a breathing effect on this device,
+        /// causing it to breathe with a single color.
+        /// </summary>
+        /// <param name="color">The color to breathe with.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        [PublicAPI]
+        void SetBreathing(Color color, int parameter = 0);
+
+        /// <summary>
+        /// Sets a breathing effect on this device,
+        /// causing it to breathe between two colors.
+        /// </summary>
+        /// <param name="first">The first color to breathe with.</param>
+        /// <param name="second">The second color to breathe with.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        [PublicAPI]
+        void SetBreathing(Color first, Color second, int parameter = 0);
 
         /// <summary>
         /// Sets a custom effect on this device.
@@ -86,11 +121,27 @@ namespace Corale.Colore.Core
         void SetReactive(Reactive effect);
 
         /// <summary>
+        /// Sets a reactive effect on this device.
+        /// </summary>
+        /// <param name="color">Color to react with.</param>
+        /// <param name="duration">How long the reaction effect should stay.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        [PublicAPI]
+        void SetReactive(Color color, Duration duration, int parameter = 0);
+
+        /// <summary>
         /// Sets a spectrum cycling effect on this device.
         /// </summary>
         /// <param name="effect">Effect options.</param>
         [PublicAPI]
         void SetSpectrumCycling(SpectrumCycling effect);
+
+        /// <summary>
+        /// Sets a spectrum cycling effect on this device.
+        /// </summary>
+        /// <param name="parameter">Additional effect parameter.</param>
+        [PublicAPI]
+        void SetSpectrumCycling(int parameter = 0);
 
         /// <summary>
         /// Sets a starlight effect on this device.
@@ -100,6 +151,24 @@ namespace Corale.Colore.Core
         void SetStarlight(Starlight effect);
 
         /// <summary>
+        /// Sets a starlight effect on this device, using random colors.
+        /// </summary>
+        /// <param name="duration">Duration of the effect.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        [PublicAPI]
+        void SetStarlight(Duration duration, int parameter = 0);
+
+        /// <summary>
+        /// Sets a starlight effect on this device, using specified colors.
+        /// </summary>
+        /// <param name="first">The first color to use.</param>
+        /// <param name="second">The second color to use.</param>
+        /// <param name="duration">Duration of the effect.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        [PublicAPI]
+        void SetStarlight(Color first, Color second, Duration duration, int parameter = 0);
+
+        /// <summary>
         /// Sets a static effect on this device.
         /// </summary>
         /// <param name="effect">Effect options.</param>
@@ -107,10 +176,26 @@ namespace Corale.Colore.Core
         void SetStatic(Static effect);
 
         /// <summary>
+        /// Sets a static effect on this device.
+        /// </summary>
+        /// <param name="color">Color to set.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        [PublicAPI]
+        void SetStatic(Color color, int parameter = 0);
+
+        /// <summary>
         /// Sets a wave effect on this device.
         /// </summary>
         /// <param name="effect">Effect options.</param>
         [PublicAPI]
         void SetWave(Wave effect);
+
+        /// <summary>
+        /// Sets a wave effect on this device.
+        /// </summary>
+        /// <param name="direction">Direction of the wave.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        [PublicAPI]
+        void SetWave(Direction direction, int parameter = 0);
     }
 }

--- a/Corale.Colore/Core/IGenericDevice.cs
+++ b/Corale.Colore/Core/IGenericDevice.cs
@@ -29,6 +29,7 @@ namespace Corale.Colore.Core
 
     using Corale.Colore.Annotations;
     using Corale.Colore.Razer;
+    using Corale.Colore.Razer.Effects;
 
     /// <summary>
     /// Interface for generic devices.
@@ -55,5 +56,61 @@ namespace Corale.Colore.Core
         /// <param name="param">Effect-specific parameter to use.</param>
         [PublicAPI]
         void SetEffect(Effect effect, IntPtr param);
+
+        /// <summary>
+        /// Sets a blinking effect on this device.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        [PublicAPI]
+        void SetBlinking(Blinking effect);
+
+        /// <summary>
+        /// Sets a breathing effect on this device.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        [PublicAPI]
+        void SetBreathing(Breathing effect);
+
+        /// <summary>
+        /// Sets a custom effect on this device.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        [PublicAPI]
+        void SetCustom(Custom effect);
+
+        /// <summary>
+        /// Sets a reactive effect on this device.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        [PublicAPI]
+        void SetReactive(Reactive effect);
+
+        /// <summary>
+        /// Sets a spectrum cycling effect on this device.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        [PublicAPI]
+        void SetSpectrumCycling(SpectrumCycling effect);
+
+        /// <summary>
+        /// Sets a starlight effect on this device.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        [PublicAPI]
+        void SetStarlight(Starlight effect);
+
+        /// <summary>
+        /// Sets a static effect on this device.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        [PublicAPI]
+        void SetStatic(Static effect);
+
+        /// <summary>
+        /// Sets a wave effect on this device.
+        /// </summary>
+        /// <param name="effect">Effect options.</param>
+        [PublicAPI]
+        void SetWave(Wave effect);
     }
 }

--- a/Corale.Colore/Core/NativeWrapper.cs
+++ b/Corale.Colore/Core/NativeWrapper.cs
@@ -234,6 +234,28 @@ namespace Corale.Colore.Core
         }
 
         /// <summary>
+        /// Helper method for creating device effects with relevant structure parameter.
+        /// </summary>
+        /// <typeparam name="T">The structure type, needs to be compatible with the effect type.</typeparam>
+        /// <param name="device">The ID of the device to create the effect for.</param>
+        /// <param name="effect">The type of effect to create.</param>
+        /// <param name="struct">The effect structure parameter.</param>
+        /// <returns>A <see cref="Guid" /> for the created effect.</returns>
+        internal static Guid CreateDeviceEffect<T>(Guid device, Effect effect, T @struct) where T : struct
+        {
+            var ptr = Marshal.AllocHGlobal(Marshal.SizeOf(@struct));
+            Marshal.StructureToPtr(@struct, ptr, false);
+            try
+            {
+                return CreateEffect(device, effect, ptr);
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(ptr);
+            }
+        }
+
+        /// <summary>
         /// Helper method for creating keyboard effects with relevant structure parameter.
         /// </summary>
         /// <typeparam name="T">The structure type, needs to be compatible with the effect type.</typeparam>

--- a/Corale.Colore/Razer/Constants.cs
+++ b/Corale.Colore/Razer/Constants.cs
@@ -31,6 +31,21 @@ namespace Corale.Colore.Razer
     public static class Constants
     {
         /// <summary>
+        /// Maximum number of rows for a generic custom effect.
+        /// </summary>
+        public const int MaxRows = 30;
+
+        /// <summary>
+        /// Maximum number of columns for a generic custom effect.
+        /// </summary>
+        public const int MaxColumns = 30;
+
+        /// <summary>
+        /// Maximum number of color entries for a generic custom effect.
+        /// </summary>
+        public const int MaxColors = MaxRows * MaxColumns;
+
+        /// <summary>
         /// Used by Razer code to send Chroma event messages.
         /// </summary>
         public const uint WmChromaEvent = WmApp + 0x2000;

--- a/Corale.Colore/Razer/DeviceType.cs
+++ b/Corale.Colore/Razer/DeviceType.cs
@@ -42,24 +42,36 @@ namespace Corale.Colore.Razer
         /// A mouse device.
         /// </summary>
         [PublicAPI]
-        Mouse,
+        Mouse = 2,
 
         /// <summary>
         /// A headset device.
         /// </summary>
         [PublicAPI]
-        Headset,
+        Headset = 3,
 
         /// <summary>
         /// A mouse pad.
         /// </summary>
         [PublicAPI]
-        Mousepad,
+        Mousepad = 4,
 
         /// <summary>
         /// A keypad.
         /// </summary>
         [PublicAPI]
-        Keypad
+        Keypad = 5,
+
+        /// <summary>
+        /// System device.
+        /// </summary>
+        [PublicAPI]
+        System = 6,
+
+        /// <summary>
+        /// Invalid device.
+        /// </summary>
+        [PublicAPI]
+        Invalid
     }
 }

--- a/Corale.Colore/Razer/Effects/Blinking.cs
+++ b/Corale.Colore/Razer/Effects/Blinking.cs
@@ -1,5 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------
-// <copyright file="Effect.cs" company="Corale">
+﻿// <copyright file="Blinking.cs" company="Corale">
 //     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
 //
 //     Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,76 +20,48 @@
 //
 //     "Razer" is a trademark of Razer USA Ltd.
 // </copyright>
-// ---------------------------------------------------------------------------------------
 
-namespace Corale.Colore.Razer
+namespace Corale.Colore.Razer.Effects
 {
+    using System.Runtime.InteropServices;
+
     using Corale.Colore.Annotations;
+    using Corale.Colore.Core;
 
     /// <summary>
-    /// Generic device effects.
+    /// Describes a blinking effect.
     /// </summary>
-    /// <remarks>Not all devices are compatible with every effect type.</remarks>
-    public enum Effect
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Blinking
     {
         /// <summary>
-        /// No effect.
+        /// The size of the struct.
         /// </summary>
         [PublicAPI]
-        None = 0,
+        public readonly int Size;
 
         /// <summary>
-        /// The wave effect.
+        /// Additional effect parameter.
         /// </summary>
         [PublicAPI]
-        Wave,
+        public readonly int Parameter;
 
         /// <summary>
-        /// Spectrum cycling effect.
+        /// Color of the blinking effect.
         /// </summary>
         [PublicAPI]
-        SpectrumCycling,
+        public readonly Color Color;
 
         /// <summary>
-        /// Slowly fades between two colors.
+        /// Initializes a new instance of the <see cref="Blinking" /> struct.
         /// </summary>
-        [PublicAPI]
-        Breathing,
-
-        /// <summary>
-        /// A blinking effect.
-        /// </summary>
-        [PublicAPI]
-        Blinking,
-
-        /// <summary>
-        /// Reacts to input.
-        /// </summary>
-        [PublicAPI]
-        Reactive,
-
-        /// <summary>
-        /// Static color.
-        /// </summary>
-        [PublicAPI]
-        Static,
-
-        /// <summary>
-        /// A custom effect.
-        /// </summary>
-        [PublicAPI]
-        Custom,
-
-        /// <summary>
-        /// The starlight effect.
-        /// </summary>
-        [PublicAPI]
-        Starlight,
-
-        /// <summary>
-        /// Invalid effect.
-        /// </summary>
-        [PublicAPI]
-        Invalid
+        /// <param name="color">The color to use for the effect.</param>
+        /// <param name="parameter">Additional parameter value to set.</param>
+        public Blinking(Color color, int parameter = 0)
+        {
+            Color = color;
+            Parameter = parameter;
+            Size = Marshal.SizeOf(typeof(Blinking));
+        }
     }
 }

--- a/Corale.Colore/Razer/Effects/Breathing.cs
+++ b/Corale.Colore/Razer/Effects/Breathing.cs
@@ -1,0 +1,113 @@
+﻿// <copyright file="Breathing.cs" company="Corale">
+//     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+
+namespace Corale.Colore.Razer.Effects
+{
+    using System.Runtime.InteropServices;
+
+    using Corale.Colore.Annotations;
+    using Corale.Colore.Core;
+
+    /// <summary>
+    /// Describes a breathing effect for a system device.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Breathing
+    {
+        /// <summary>
+        /// The size of the struct.
+        /// </summary>
+        [PublicAPI]
+        public readonly int Size;
+
+        /// <summary>
+        /// Additional effect parameter.
+        /// </summary>
+        [PublicAPI]
+        public readonly int Parameter;
+
+        /// <summary>
+        /// The type of breathing effect.
+        /// </summary>
+        [PublicAPI]
+        public readonly BreathingType Type;
+
+        /// <summary>
+        /// Primary color to breathe with.
+        /// </summary>
+        [PublicAPI]
+        public readonly Color First;
+
+        /// <summary>
+        /// Secondary color to breathe with.
+        /// </summary>
+        [PublicAPI]
+        public readonly Color Second;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Breathing" /> struct.
+        /// </summary>
+        /// <param name="type">The type of breathing effect to create.</param>
+        /// <param name="first">Primary effect color.</param>
+        /// <param name="second">Secondary effect color.</param>
+        /// <param name="parameter">Additional effect parameter to set.</param>
+        public Breathing(BreathingType type, Color first, Color second, int parameter = 0)
+        {
+            Type = type;
+            First = first;
+            Second = second;
+            Parameter = parameter;
+            Size = Marshal.SizeOf(typeof(Breathing));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Breathing" /> struct.
+        /// </summary>
+        /// <param name="color">Color to breathe with.</param>
+        /// <param name="parameter">Additional effect parameter to set.</param>
+        public Breathing(Color color, int parameter = 0)
+            : this(BreathingType.One, color, Color.Black, parameter)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Breathing" /> struct.
+        /// </summary>
+        /// <param name="first">Primary effect color.</param>
+        /// <param name="second">Secondary effect color.</param>
+        /// <param name="parameter">Additional effect parameter to set.</param>
+        public Breathing(Color first, Color second, int parameter = 0)
+            : this(BreathingType.Two, first, second, parameter)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Breathing" /> struct.
+        /// </summary>
+        /// <param name="parameter">Additional effect parameter to set.</param>
+        public Breathing(int parameter = 0)
+            : this(BreathingType.Random, Color.Black, Color.Black, parameter)
+        {
+        }
+    }
+}

--- a/Corale.Colore/Razer/Effects/Breathing.cs
+++ b/Corale.Colore/Razer/Effects/Breathing.cs
@@ -105,9 +105,20 @@ namespace Corale.Colore.Razer.Effects
         /// Initializes a new instance of the <see cref="Breathing" /> struct.
         /// </summary>
         /// <param name="parameter">Additional effect parameter to set.</param>
-        public Breathing(int parameter = 0)
+        public Breathing(int parameter)
             : this(BreathingType.Random, Color.Black, Color.Black, parameter)
         {
+        }
+
+        /// <summary>
+        /// Returns a new instance of the <see cref="Breathing" /> struct
+        /// setup to perform random breathing with the parameter set to
+        /// zero.
+        /// </summary>
+        /// <returns>A new instance of the <see cref="Breathing" /> struct.</returns>
+        public static Breathing Create()
+        {
+            return new Breathing(0);
         }
     }
 }

--- a/Corale.Colore/Razer/Effects/BreathingType.cs
+++ b/Corale.Colore/Razer/Effects/BreathingType.cs
@@ -1,5 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------
-// <copyright file="Effect.cs" company="Corale">
+﻿// <copyright file="BreathingType.cs" company="Corale">
 //     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
 //
 //     Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,76 +20,32 @@
 //
 //     "Razer" is a trademark of Razer USA Ltd.
 // </copyright>
-// ---------------------------------------------------------------------------------------
 
-namespace Corale.Colore.Razer
+namespace Corale.Colore.Razer.Effects
 {
     using Corale.Colore.Annotations;
 
     /// <summary>
-    /// Generic device effects.
+    /// Supported breathing effect types for system devices.
     /// </summary>
-    /// <remarks>Not all devices are compatible with every effect type.</remarks>
-    public enum Effect
+    public enum BreathingType
     {
         /// <summary>
-        /// No effect.
+        /// Device fades between one color and no color.
         /// </summary>
         [PublicAPI]
-        None = 0,
+        One = 1,
 
         /// <summary>
-        /// The wave effect.
+        /// Device fades between two specified colors.
         /// </summary>
         [PublicAPI]
-        Wave,
+        Two,
 
         /// <summary>
-        /// Spectrum cycling effect.
+        /// Device fades between random colors.
         /// </summary>
         [PublicAPI]
-        SpectrumCycling,
-
-        /// <summary>
-        /// Slowly fades between two colors.
-        /// </summary>
-        [PublicAPI]
-        Breathing,
-
-        /// <summary>
-        /// A blinking effect.
-        /// </summary>
-        [PublicAPI]
-        Blinking,
-
-        /// <summary>
-        /// Reacts to input.
-        /// </summary>
-        [PublicAPI]
-        Reactive,
-
-        /// <summary>
-        /// Static color.
-        /// </summary>
-        [PublicAPI]
-        Static,
-
-        /// <summary>
-        /// A custom effect.
-        /// </summary>
-        [PublicAPI]
-        Custom,
-
-        /// <summary>
-        /// The starlight effect.
-        /// </summary>
-        [PublicAPI]
-        Starlight,
-
-        /// <summary>
-        /// Invalid effect.
-        /// </summary>
-        [PublicAPI]
-        Invalid
+        Random
     }
 }

--- a/Corale.Colore/Razer/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Effects/Custom.cs
@@ -238,12 +238,11 @@ namespace Corale.Colore.Razer.Effects
         /// <summary>
         /// Creates a new empty <see cref="Custom" /> struct.
         /// </summary>
-        /// <param name="parameter">Additional effect parameter to set.</param>
         /// <returns>An instance of <see cref="Custom" />
         /// filled with the color black.</returns>
-        public static Custom Create(int parameter = 0)
+        public static Custom Create()
         {
-            return new Custom(Color.Black, parameter);
+            return new Custom(Color.Black);
         }
 
         /// <summary>

--- a/Corale.Colore/Razer/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Effects/Custom.cs
@@ -1,0 +1,335 @@
+﻿// <copyright file="Custom.cs" company="Corale">
+//     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+
+namespace Corale.Colore.Razer.Effects
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.InteropServices;
+
+    using Corale.Colore.Annotations;
+    using Corale.Colore.Core;
+
+    /// <summary>
+    /// Describes a custom effect for a system device.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Custom : IEquatable<Custom>
+    {
+        /// <summary>
+        /// The size of the effect struct.
+        /// </summary>
+        [PublicAPI]
+        public readonly int Size;
+
+        /// <summary>
+        /// Additional effect parameter.
+        /// </summary>
+        [PublicAPI]
+        public readonly int Parameter;
+
+        /// <summary>
+        /// Color values for the effect.
+        /// </summary>
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = Constants.MaxColors)]
+        private readonly Color[] _colors;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Custom" /> struct.
+        /// </summary>
+        /// <param name="color">Color to set on all cells.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public Custom(Color color, int parameter = 0)
+            : this(parameter)
+        {
+            for (var index = 0; index < Constants.MaxColors; index++)
+                this[index] = color;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Custom" /> struct.
+        /// </summary>
+        /// <param name="other">Another <see cref="Custom" /> struct to copy colors and data from.</param>
+        public Custom(Custom other)
+            : this(other.Parameter)
+        {
+            for (var index = 0; index < Constants.MaxColors; index++)
+                this[index] = other[index];
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Custom" /> struct.
+        /// </summary>
+        /// <param name="colors">Colors to set.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public Custom(IList<Color> colors, int parameter = 0)
+            : this(parameter)
+        {
+            if (colors.Count != Constants.MaxColors)
+                throw new ArgumentException("Color array must contain correct number of colors.", nameof(colors));
+
+            for (var index = 0; index < Constants.MaxColors; index++)
+                this[index] = colors[index];
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Custom" /> struct.
+        /// </summary>
+        /// <param name="colors">2D array of colors to set.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public Custom(Color[,] colors, int parameter = 0)
+            : this(parameter)
+        {
+            if (colors.GetLength(0) != Constants.MaxRows)
+                throw new ArgumentException("Color array has invalid number of rows.", nameof(colors));
+
+            if (colors.GetLength(1) != Constants.MaxColumns)
+                throw new ArgumentException("Color array has invalid number of columns.", nameof(colors));
+
+            for (var row = 0; row < Constants.MaxRows; row++)
+            {
+                for (var column = 0; column < Constants.MaxColumns; column++)
+                    this[row, column] = colors[row, column];
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Custom" /> struct.
+        /// </summary>
+        /// <param name="parameter">Effect parameter to set.</param>
+        private Custom(int parameter)
+        {
+            _colors = new Color[Constants.MaxColors];
+            Parameter = parameter;
+            Size = Marshal.SizeOf(typeof(Custom));
+        }
+
+        /// <summary>
+        /// Gets or sets a position in the custom grid.
+        /// </summary>
+        /// <param name="index">Index to access.</param>
+        /// <returns>The <see cref="Color" /> at the specified position.</returns>
+        [PublicAPI]
+        public Color this[int index]
+        {
+            get
+            {
+                if (index < 0 || index >= Constants.MaxColors)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(index),
+                        index,
+                        "Attempted to access an index that does not exist.");
+                }
+
+                return _colors[index];
+            }
+
+            set
+            {
+                if (index < 0 || index >= Constants.MaxColors)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(index),
+                        index,
+                        "Attempted to access an index that does not exist.");
+                }
+
+                _colors[index] = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets cells in the custom grid.
+        /// </summary>
+        /// <param name="row">The row to access.</param>
+        /// <param name="column">The column to access.</param>
+        /// <returns>The <see cref="Color" /> at the specified position.</returns>
+        [PublicAPI]
+        public Color this[int row, int column]
+        {
+            get
+            {
+                if (row < 0 || row >= Constants.MaxRows)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(row),
+                        row,
+                        "Attempted to access a row that does not exist.");
+                }
+
+                if (column < 0 || column >= Constants.MaxColumns)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(column),
+                        column,
+                        "Attempted to access a column that does not exist.");
+                }
+
+                return this[column + row * Constants.MaxColumns];
+            }
+
+            set
+            {
+                if (row < 0 || row >= Constants.MaxRows)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(row),
+                        row,
+                        "Attempted to access a row that does not exist.");
+                }
+
+                if (column < 0 || column >= Constants.MaxColumns)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(column),
+                        column,
+                        "Attempted to access a column that does not exist.");
+                }
+
+                this[column + row * Constants.MaxColumns] = value;
+            }
+        }
+
+        /// <summary>
+        /// Compares an instance of <see cref="Custom" /> with
+        /// another object for equality.
+        /// </summary>
+        /// <param name="left">The left operand, an instance of <see cref="Custom" />.</param>
+        /// <param name="right">The right operand, any type of object.</param>
+        /// <returns><c>true</c> if the two objects are equal, otherwise <c>false</c>.</returns>
+        public static bool operator ==(Custom left, object right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <summary>
+        /// Compares an instance of <see cref="Custom" /> with
+        /// another object for inequality.
+        /// </summary>
+        /// <param name="left">The left operand, an instance of <see cref="Custom" />.</param>
+        /// <param name="right">The right operand, any type of object.</param>
+        /// <returns><c>true</c> if the two objects are not equal, otherwise <c>false</c>.</returns>
+        public static bool operator !=(Custom left, object right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <summary>
+        /// Creates a new empty <see cref="Custom" /> struct.
+        /// </summary>
+        /// <param name="parameter">Additional effect parameter to set.</param>
+        /// <returns>An instance of <see cref="Custom" />
+        /// filled with the color black.</returns>
+        public static Custom Create(int parameter = 0)
+        {
+            return new Custom(Color.Black, parameter);
+        }
+
+        /// <summary>
+        /// Returns a copy of this struct.
+        /// </summary>
+        /// <returns>A copy of this struct.</returns>
+        [PublicAPI]
+        public Custom Clone()
+        {
+            return new Custom(this);
+        }
+
+        /// <summary>
+        /// Clears the colors from the grid, setting them to <see cref="Color.Black" />.
+        /// </summary>
+        [PublicAPI]
+        public void Clear()
+        {
+            Set(Color.Black);
+        }
+
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if <paramref name="obj"/> and this instance are of compatible types
+        /// and represent the same value; otherwise, <c>false</c>.
+        /// </returns>
+        /// <param name="obj">Another object to compare to. </param>
+        /// <filterpriority>2</filterpriority>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(obj, null))
+                return false;
+
+            if (!(obj is Custom))
+                return false;
+
+            return Equals((Custom)obj);
+        }
+
+        /// <summary>
+        /// Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <returns>
+        /// <c>true</c> if the current object is equal to the <paramref name="other"/> parameter;
+        /// otherwise, <c>false</c>.
+        /// </returns>
+        /// <param name="other">A <see cref="Custom" /> to compare with this object.</param>
+        public bool Equals(Custom other)
+        {
+            for (var index = 0; index < Constants.MaxColors; index++)
+            {
+                if (this[index] != other[index])
+                    return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Returns the hash code for this instance.
+        /// </summary>
+        /// <returns>A 32-bit signed integer that is the hash code for this instance.</returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Size;
+                hashCode = (hashCode * 397) ^ Parameter;
+                hashCode = (hashCode * 397) ^ (_colors?.GetHashCode() ?? 0);
+                return hashCode;
+            }
+        }
+
+        /// <summary>
+        /// Sets the entire grid to a specific <see cref="Color" />.
+        /// </summary>
+        /// <param name="color">The <see cref="Color" /> to apply.</param>
+        [PublicAPI]
+        public void Set(Color color)
+        {
+            for (var index = 0; index < Constants.MaxColors; index++)
+            {
+                this[index] = color;
+            }
+        }
+    }
+}

--- a/Corale.Colore/Razer/Effects/Direction.cs
+++ b/Corale.Colore/Razer/Effects/Direction.cs
@@ -1,5 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------
-// <copyright file="Effect.cs" company="Corale">
+﻿// <copyright file="Direction.cs" company="Corale">
 //     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
 //
 //     Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,76 +20,38 @@
 //
 //     "Razer" is a trademark of Razer USA Ltd.
 // </copyright>
-// ---------------------------------------------------------------------------------------
 
-namespace Corale.Colore.Razer
+namespace Corale.Colore.Razer.Effects
 {
     using Corale.Colore.Annotations;
 
     /// <summary>
-    /// Generic device effects.
+    /// Supported directions for the system wave effect.
     /// </summary>
-    /// <remarks>Not all devices are compatible with every effect type.</remarks>
-    public enum Effect
+    public enum Direction
     {
         /// <summary>
-        /// No effect.
+        /// Left to right.
         /// </summary>
         [PublicAPI]
-        None = 0,
+        LeftToRight = 1,
 
         /// <summary>
-        /// The wave effect.
+        /// Right to left.
         /// </summary>
         [PublicAPI]
-        Wave,
+        RightToLeft,
 
         /// <summary>
-        /// Spectrum cycling effect.
+        /// Front to back.
         /// </summary>
         [PublicAPI]
-        SpectrumCycling,
+        FrontToBack,
 
         /// <summary>
-        /// Slowly fades between two colors.
+        /// Back to front.
         /// </summary>
         [PublicAPI]
-        Breathing,
-
-        /// <summary>
-        /// A blinking effect.
-        /// </summary>
-        [PublicAPI]
-        Blinking,
-
-        /// <summary>
-        /// Reacts to input.
-        /// </summary>
-        [PublicAPI]
-        Reactive,
-
-        /// <summary>
-        /// Static color.
-        /// </summary>
-        [PublicAPI]
-        Static,
-
-        /// <summary>
-        /// A custom effect.
-        /// </summary>
-        [PublicAPI]
-        Custom,
-
-        /// <summary>
-        /// The starlight effect.
-        /// </summary>
-        [PublicAPI]
-        Starlight,
-
-        /// <summary>
-        /// Invalid effect.
-        /// </summary>
-        [PublicAPI]
-        Invalid
+        BackToFront
     }
 }

--- a/Corale.Colore/Razer/Effects/Duration.cs
+++ b/Corale.Colore/Razer/Effects/Duration.cs
@@ -1,5 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------
-// <copyright file="Effect.cs" company="Corale">
+﻿// <copyright file="Duration.cs" company="Corale">
 //     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
 //
 //     Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,76 +20,32 @@
 //
 //     "Razer" is a trademark of Razer USA Ltd.
 // </copyright>
-// ---------------------------------------------------------------------------------------
 
-namespace Corale.Colore.Razer
+namespace Corale.Colore.Razer.Effects
 {
     using Corale.Colore.Annotations;
 
     /// <summary>
-    /// Generic device effects.
+    /// Effect durations for system reactive effect.
     /// </summary>
-    /// <remarks>Not all devices are compatible with every effect type.</remarks>
-    public enum Effect
+    public enum Duration
     {
         /// <summary>
-        /// No effect.
+        /// Short duration.
         /// </summary>
         [PublicAPI]
-        None = 0,
+        Short = 1,
 
         /// <summary>
-        /// The wave effect.
+        /// Medium duration.
         /// </summary>
         [PublicAPI]
-        Wave,
+        Medium,
 
         /// <summary>
-        /// Spectrum cycling effect.
+        /// Long duration.
         /// </summary>
         [PublicAPI]
-        SpectrumCycling,
-
-        /// <summary>
-        /// Slowly fades between two colors.
-        /// </summary>
-        [PublicAPI]
-        Breathing,
-
-        /// <summary>
-        /// A blinking effect.
-        /// </summary>
-        [PublicAPI]
-        Blinking,
-
-        /// <summary>
-        /// Reacts to input.
-        /// </summary>
-        [PublicAPI]
-        Reactive,
-
-        /// <summary>
-        /// Static color.
-        /// </summary>
-        [PublicAPI]
-        Static,
-
-        /// <summary>
-        /// A custom effect.
-        /// </summary>
-        [PublicAPI]
-        Custom,
-
-        /// <summary>
-        /// The starlight effect.
-        /// </summary>
-        [PublicAPI]
-        Starlight,
-
-        /// <summary>
-        /// Invalid effect.
-        /// </summary>
-        [PublicAPI]
-        Invalid
+        Long
     }
 }

--- a/Corale.Colore/Razer/Effects/None.cs
+++ b/Corale.Colore/Razer/Effects/None.cs
@@ -1,5 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------
-// <copyright file="Effect.cs" company="Corale">
+﻿// <copyright file="None.cs" company="Corale">
 //     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
 //
 //     Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,76 +20,39 @@
 //
 //     "Razer" is a trademark of Razer USA Ltd.
 // </copyright>
-// ---------------------------------------------------------------------------------------
 
-namespace Corale.Colore.Razer
+namespace Corale.Colore.Razer.Effects
 {
+    using System.Runtime.InteropServices;
+
     using Corale.Colore.Annotations;
 
     /// <summary>
-    /// Generic device effects.
+    /// Describes the <c>NO_EFFECT</c> effect.
     /// </summary>
-    /// <remarks>Not all devices are compatible with every effect type.</remarks>
-    public enum Effect
+    [StructLayout(LayoutKind.Sequential)]
+    public struct None
     {
         /// <summary>
-        /// No effect.
+        /// The size of the struct.
         /// </summary>
         [PublicAPI]
-        None = 0,
+        public readonly int Size;
 
         /// <summary>
-        /// The wave effect.
+        /// Additional effect parameter.
         /// </summary>
         [PublicAPI]
-        Wave,
+        public readonly int Parameter;
 
         /// <summary>
-        /// Spectrum cycling effect.
+        /// Initializes a new instance of the <see cref="None" /> struct.
         /// </summary>
-        [PublicAPI]
-        SpectrumCycling,
-
-        /// <summary>
-        /// Slowly fades between two colors.
-        /// </summary>
-        [PublicAPI]
-        Breathing,
-
-        /// <summary>
-        /// A blinking effect.
-        /// </summary>
-        [PublicAPI]
-        Blinking,
-
-        /// <summary>
-        /// Reacts to input.
-        /// </summary>
-        [PublicAPI]
-        Reactive,
-
-        /// <summary>
-        /// Static color.
-        /// </summary>
-        [PublicAPI]
-        Static,
-
-        /// <summary>
-        /// A custom effect.
-        /// </summary>
-        [PublicAPI]
-        Custom,
-
-        /// <summary>
-        /// The starlight effect.
-        /// </summary>
-        [PublicAPI]
-        Starlight,
-
-        /// <summary>
-        /// Invalid effect.
-        /// </summary>
-        [PublicAPI]
-        Invalid
+        /// <param name="parameter">Additional effect parameter to set.</param>
+        public None(int parameter = 0)
+        {
+            Parameter = parameter;
+            Size = Marshal.SizeOf(typeof(None));
+        }
     }
 }

--- a/Corale.Colore/Razer/Effects/Reactive.cs
+++ b/Corale.Colore/Razer/Effects/Reactive.cs
@@ -1,5 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------
-// <copyright file="Effect.cs" company="Corale">
+﻿// <copyright file="Reactive.cs" company="Corale">
 //     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
 //
 //     Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,76 +20,56 @@
 //
 //     "Razer" is a trademark of Razer USA Ltd.
 // </copyright>
-// ---------------------------------------------------------------------------------------
 
-namespace Corale.Colore.Razer
+namespace Corale.Colore.Razer.Effects
 {
+    using System.Runtime.InteropServices;
+
     using Corale.Colore.Annotations;
+    using Corale.Colore.Core;
 
     /// <summary>
-    /// Generic device effects.
+    /// Describes the reactive effect for system devices.
     /// </summary>
-    /// <remarks>Not all devices are compatible with every effect type.</remarks>
-    public enum Effect
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Reactive
     {
         /// <summary>
-        /// No effect.
+        /// The size of the struct.
         /// </summary>
         [PublicAPI]
-        None = 0,
+        public readonly int Size;
 
         /// <summary>
-        /// The wave effect.
+        /// Additional effect parameter.
         /// </summary>
         [PublicAPI]
-        Wave,
+        public readonly int Parameter;
 
         /// <summary>
-        /// Spectrum cycling effect.
+        /// Duration of the effect.
         /// </summary>
         [PublicAPI]
-        SpectrumCycling,
+        public readonly Duration Duration;
 
         /// <summary>
-        /// Slowly fades between two colors.
+        /// Color of the effect.
         /// </summary>
         [PublicAPI]
-        Breathing,
+        public readonly Color Color;
 
         /// <summary>
-        /// A blinking effect.
+        /// Initializes a new instance of the <see cref="Reactive" /> struct.
         /// </summary>
-        [PublicAPI]
-        Blinking,
-
-        /// <summary>
-        /// Reacts to input.
-        /// </summary>
-        [PublicAPI]
-        Reactive,
-
-        /// <summary>
-        /// Static color.
-        /// </summary>
-        [PublicAPI]
-        Static,
-
-        /// <summary>
-        /// A custom effect.
-        /// </summary>
-        [PublicAPI]
-        Custom,
-
-        /// <summary>
-        /// The starlight effect.
-        /// </summary>
-        [PublicAPI]
-        Starlight,
-
-        /// <summary>
-        /// Invalid effect.
-        /// </summary>
-        [PublicAPI]
-        Invalid
+        /// <param name="duration">Effect duration.</param>
+        /// <param name="color">Effect color.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public Reactive(Duration duration, Color color, int parameter = 0)
+        {
+            Duration = duration;
+            Color = color;
+            Parameter = parameter;
+            Size = Marshal.SizeOf(typeof(Reactive));
+        }
     }
 }

--- a/Corale.Colore/Razer/Effects/SpectrumCycling.cs
+++ b/Corale.Colore/Razer/Effects/SpectrumCycling.cs
@@ -1,5 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------
-// <copyright file="Effect.cs" company="Corale">
+﻿// <copyright file="SpectrumCycling.cs" company="Corale">
 //     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
 //
 //     Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,76 +20,39 @@
 //
 //     "Razer" is a trademark of Razer USA Ltd.
 // </copyright>
-// ---------------------------------------------------------------------------------------
 
-namespace Corale.Colore.Razer
+namespace Corale.Colore.Razer.Effects
 {
+    using System.Runtime.InteropServices;
+
     using Corale.Colore.Annotations;
 
     /// <summary>
-    /// Generic device effects.
+    /// Describes the spectrum cycling effect for system devices.
     /// </summary>
-    /// <remarks>Not all devices are compatible with every effect type.</remarks>
-    public enum Effect
+    [StructLayout(LayoutKind.Sequential)]
+    public struct SpectrumCycling
     {
         /// <summary>
-        /// No effect.
+        /// The size of the struct.
         /// </summary>
         [PublicAPI]
-        None = 0,
+        public readonly int Size;
 
         /// <summary>
-        /// The wave effect.
+        /// Additional effect parameter.
         /// </summary>
         [PublicAPI]
-        Wave,
+        public readonly int Parameter;
 
         /// <summary>
-        /// Spectrum cycling effect.
+        /// Initializes a new instance of the <see cref="SpectrumCycling" /> struct.
         /// </summary>
-        [PublicAPI]
-        SpectrumCycling,
-
-        /// <summary>
-        /// Slowly fades between two colors.
-        /// </summary>
-        [PublicAPI]
-        Breathing,
-
-        /// <summary>
-        /// A blinking effect.
-        /// </summary>
-        [PublicAPI]
-        Blinking,
-
-        /// <summary>
-        /// Reacts to input.
-        /// </summary>
-        [PublicAPI]
-        Reactive,
-
-        /// <summary>
-        /// Static color.
-        /// </summary>
-        [PublicAPI]
-        Static,
-
-        /// <summary>
-        /// A custom effect.
-        /// </summary>
-        [PublicAPI]
-        Custom,
-
-        /// <summary>
-        /// The starlight effect.
-        /// </summary>
-        [PublicAPI]
-        Starlight,
-
-        /// <summary>
-        /// Invalid effect.
-        /// </summary>
-        [PublicAPI]
-        Invalid
+        /// <param name="parameter">Additional effect parameter to set.</param>
+        public SpectrumCycling(int parameter = 0)
+        {
+            Parameter = parameter;
+            Size = Marshal.SizeOf(typeof(None));
+        }
     }
 }

--- a/Corale.Colore/Razer/Effects/SpectrumCycling.cs
+++ b/Corale.Colore/Razer/Effects/SpectrumCycling.cs
@@ -49,10 +49,20 @@ namespace Corale.Colore.Razer.Effects
         /// Initializes a new instance of the <see cref="SpectrumCycling" /> struct.
         /// </summary>
         /// <param name="parameter">Additional effect parameter to set.</param>
-        public SpectrumCycling(int parameter = 0)
+        public SpectrumCycling(int parameter)
         {
             Parameter = parameter;
             Size = Marshal.SizeOf(typeof(None));
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="SpectrumCycling" /> struct
+        /// with default values.
+        /// </summary>
+        /// <returns>A new instance of the <see cref="SpectrumCycling" /> struct.</returns>
+        public static SpectrumCycling Create()
+        {
+            return new SpectrumCycling(0);
         }
     }
 }

--- a/Corale.Colore/Razer/Effects/Starlight.cs
+++ b/Corale.Colore/Razer/Effects/Starlight.cs
@@ -1,0 +1,113 @@
+﻿// <copyright file="Starlight.cs" company="Corale">
+//     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
+//
+//     Permission is hereby granted, free of charge, to any person obtaining a copy of
+//     this software and associated documentation files (the "Software"), to deal in
+//     the Software without restriction, including without limitation the rights to
+//     use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+//     of the Software, and to permit persons to whom the Software is furnished to do
+//     so, subject to the following conditions:
+//
+//     The above copyright notice and this permission notice shall be included in all
+//     copies or substantial portions of the Software.
+//
+//     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+//     CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+//     "Razer" is a trademark of Razer USA Ltd.
+// </copyright>
+
+namespace Corale.Colore.Razer.Effects
+{
+    using System.Runtime.InteropServices;
+
+    using Corale.Colore.Annotations;
+    using Corale.Colore.Core;
+
+    /// <summary>
+    /// Describes the starlight effect for system devices.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Starlight
+    {
+        /// <summary>
+        /// The size of the struct.
+        /// </summary>
+        [PublicAPI]
+        public readonly int Size;
+
+        /// <summary>
+        /// Additional effect parameter.
+        /// </summary>
+        [PublicAPI]
+        public readonly int Parameter;
+
+        /// <summary>
+        /// The starlight effect type.
+        /// </summary>
+        [PublicAPI]
+        public readonly StarlightType Type;
+
+        /// <summary>
+        /// First color of the effect.
+        /// </summary>
+        [PublicAPI]
+        public readonly Color First;
+
+        /// <summary>
+        /// Second color of the effect.
+        /// </summary>
+        [PublicAPI]
+        public readonly Color Second;
+
+        /// <summary>
+        /// Effect duration.
+        /// </summary>
+        [PublicAPI]
+        public readonly Duration Duration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Starlight" /> struct.
+        /// </summary>
+        /// <param name="type">The type of starlight effect to make.</param>
+        /// <param name="duration">Duration of the effect.</param>
+        /// <param name="first">First color of the effect.</param>
+        /// <param name="second">Second color of the effect.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public Starlight(StarlightType type, Duration duration, Color first, Color second, int parameter = 0)
+        {
+            Type = type;
+            Duration = duration;
+            First = first;
+            Second = second;
+            Parameter = parameter;
+            Size = Marshal.SizeOf(typeof(Starlight));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Starlight" /> struct.
+        /// </summary>
+        /// <param name="duration">Effect duration.</param>
+        /// <param name="first">First color of the effect.</param>
+        /// <param name="second">Second color of the effect.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public Starlight(Duration duration, Color first, Color second, int parameter = 0)
+            : this(StarlightType.Two, duration, first, second, parameter)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Starlight" /> struct.
+        /// </summary>
+        /// <param name="duration">Effect duration.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public Starlight(Duration duration, int parameter = 0)
+            : this(StarlightType.Random, duration, Color.Black, Color.Black, parameter)
+        {
+        }
+    }
+}

--- a/Corale.Colore/Razer/Effects/StarlightType.cs
+++ b/Corale.Colore/Razer/Effects/StarlightType.cs
@@ -1,5 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------
-// <copyright file="Effect.cs" company="Corale">
+﻿// <copyright file="StarlightType.cs" company="Corale">
 //     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
 //
 //     Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,76 +20,26 @@
 //
 //     "Razer" is a trademark of Razer USA Ltd.
 // </copyright>
-// ---------------------------------------------------------------------------------------
 
-namespace Corale.Colore.Razer
+namespace Corale.Colore.Razer.Effects
 {
     using Corale.Colore.Annotations;
 
     /// <summary>
-    /// Generic device effects.
+    /// Supported starlight effect types for system devices.
     /// </summary>
-    /// <remarks>Not all devices are compatible with every effect type.</remarks>
-    public enum Effect
+    public enum StarlightType
     {
         /// <summary>
-        /// No effect.
+        /// Two colors.
         /// </summary>
         [PublicAPI]
-        None = 0,
+        Two = 1,
 
         /// <summary>
-        /// The wave effect.
+        /// Random colors.
         /// </summary>
         [PublicAPI]
-        Wave,
-
-        /// <summary>
-        /// Spectrum cycling effect.
-        /// </summary>
-        [PublicAPI]
-        SpectrumCycling,
-
-        /// <summary>
-        /// Slowly fades between two colors.
-        /// </summary>
-        [PublicAPI]
-        Breathing,
-
-        /// <summary>
-        /// A blinking effect.
-        /// </summary>
-        [PublicAPI]
-        Blinking,
-
-        /// <summary>
-        /// Reacts to input.
-        /// </summary>
-        [PublicAPI]
-        Reactive,
-
-        /// <summary>
-        /// Static color.
-        /// </summary>
-        [PublicAPI]
-        Static,
-
-        /// <summary>
-        /// A custom effect.
-        /// </summary>
-        [PublicAPI]
-        Custom,
-
-        /// <summary>
-        /// The starlight effect.
-        /// </summary>
-        [PublicAPI]
-        Starlight,
-
-        /// <summary>
-        /// Invalid effect.
-        /// </summary>
-        [PublicAPI]
-        Invalid
+        Random
     }
 }

--- a/Corale.Colore/Razer/Effects/Static.cs
+++ b/Corale.Colore/Razer/Effects/Static.cs
@@ -1,5 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------
-// <copyright file="Effect.cs" company="Corale">
+﻿// <copyright file="Static.cs" company="Corale">
 //     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
 //
 //     Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,76 +20,48 @@
 //
 //     "Razer" is a trademark of Razer USA Ltd.
 // </copyright>
-// ---------------------------------------------------------------------------------------
 
-namespace Corale.Colore.Razer
+namespace Corale.Colore.Razer.Effects
 {
+    using System.Runtime.InteropServices;
+
     using Corale.Colore.Annotations;
+    using Corale.Colore.Core;
 
     /// <summary>
-    /// Generic device effects.
+    /// Describes the static effect for system devices.
     /// </summary>
-    /// <remarks>Not all devices are compatible with every effect type.</remarks>
-    public enum Effect
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Static
     {
         /// <summary>
-        /// No effect.
+        /// The size of the struct.
         /// </summary>
         [PublicAPI]
-        None = 0,
+        public readonly int Size;
 
         /// <summary>
-        /// The wave effect.
+        /// Additional effect parameter.
         /// </summary>
         [PublicAPI]
-        Wave,
+        public readonly int Parameter;
 
         /// <summary>
-        /// Spectrum cycling effect.
+        /// Effect color.
         /// </summary>
         [PublicAPI]
-        SpectrumCycling,
+        public readonly Color Color;
 
         /// <summary>
-        /// Slowly fades between two colors.
+        /// Initializes a new instance of the <see cref="Static" /> struct.
         /// </summary>
-        [PublicAPI]
-        Breathing,
-
-        /// <summary>
-        /// A blinking effect.
-        /// </summary>
-        [PublicAPI]
-        Blinking,
-
-        /// <summary>
-        /// Reacts to input.
-        /// </summary>
-        [PublicAPI]
-        Reactive,
-
-        /// <summary>
-        /// Static color.
-        /// </summary>
-        [PublicAPI]
-        Static,
-
-        /// <summary>
-        /// A custom effect.
-        /// </summary>
-        [PublicAPI]
-        Custom,
-
-        /// <summary>
-        /// The starlight effect.
-        /// </summary>
-        [PublicAPI]
-        Starlight,
-
-        /// <summary>
-        /// Invalid effect.
-        /// </summary>
-        [PublicAPI]
-        Invalid
+        /// <param name="color">The color to use.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public Static(Color color, int parameter = 0)
+        {
+            Color = color;
+            Parameter = parameter;
+            Size = Marshal.SizeOf(typeof(Static));
+        }
     }
 }

--- a/Corale.Colore/Razer/Effects/Wave.cs
+++ b/Corale.Colore/Razer/Effects/Wave.cs
@@ -1,5 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------
-// <copyright file="Effect.cs" company="Corale">
+﻿// <copyright file="Wave.cs" company="Corale">
 //     Copyright © 2015-2016 by Adam Hellberg and Brandon Scott.
 //
 //     Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -21,76 +20,47 @@
 //
 //     "Razer" is a trademark of Razer USA Ltd.
 // </copyright>
-// ---------------------------------------------------------------------------------------
 
-namespace Corale.Colore.Razer
+namespace Corale.Colore.Razer.Effects
 {
+    using System.Runtime.InteropServices;
+
     using Corale.Colore.Annotations;
 
     /// <summary>
-    /// Generic device effects.
+    /// Describes the wave effect for a system device.
     /// </summary>
-    /// <remarks>Not all devices are compatible with every effect type.</remarks>
-    public enum Effect
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Wave
     {
         /// <summary>
-        /// No effect.
+        /// The size of the struct.
         /// </summary>
         [PublicAPI]
-        None = 0,
+        public readonly int Size;
 
         /// <summary>
-        /// The wave effect.
+        /// Additional effect parameter.
         /// </summary>
         [PublicAPI]
-        Wave,
+        public readonly int Parameter;
 
         /// <summary>
-        /// Spectrum cycling effect.
+        /// Direction of the wave.
         /// </summary>
         [PublicAPI]
-        SpectrumCycling,
+        public readonly Direction Direction;
 
         /// <summary>
-        /// Slowly fades between two colors.
+        /// Initializes a new instance of the <see cref="Wave" /> struct.
         /// </summary>
-        [PublicAPI]
-        Breathing,
-
-        /// <summary>
-        /// A blinking effect.
-        /// </summary>
-        [PublicAPI]
-        Blinking,
-
-        /// <summary>
-        /// Reacts to input.
-        /// </summary>
-        [PublicAPI]
-        Reactive,
-
-        /// <summary>
-        /// Static color.
-        /// </summary>
-        [PublicAPI]
-        Static,
-
-        /// <summary>
-        /// A custom effect.
-        /// </summary>
-        [PublicAPI]
-        Custom,
-
-        /// <summary>
-        /// The starlight effect.
-        /// </summary>
-        [PublicAPI]
-        Starlight,
-
-        /// <summary>
-        /// Invalid effect.
-        /// </summary>
-        [PublicAPI]
-        Invalid
+        /// <param name="direction">Direction of the wave.</param>
+        /// <param name="parameter">Additional effect parameter.</param>
+        public Wave(Direction direction, int parameter = 0)
+        {
+            Direction = direction;
+            Parameter = parameter;
+            Size = Marshal.SizeOf(typeof(Wave));
+        }
     }
 }

--- a/Corale.Colore/Razer/Keyboard/Effects/BreathingType.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/BreathingType.cs
@@ -28,7 +28,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
     using Corale.Colore.Annotations;
 
     /// <summary>
-    /// Supported breathing effect types for mouse pads.
+    /// Supported breathing effect types for keyboards.
     /// </summary>
     public enum BreathingType
     {


### PR DESCRIPTION
This implements the new system effects and exposes them via methods on `GenericDevice`.

To use these effects, one would need to get an instance of `GenericDevice` by calling the `Get` method with a valid device GUID, either on the `Chroma` class or directly on `GenericDevice`.

All of the system effects accept an optional additional integer parameter, which is present in the Chroma SDK but is currently unused.

When this undocumented parameter is given a purpose, it will already have support in Colore.

Updates #143.