### PR TITLE
Set the version of the Colore dependency explicitly

### DIFF
--- a/Corale.Colore.WinForms/Corale.Colore.WinForms.nuspec
+++ b/Corale.Colore.WinForms/Corale.Colore.WinForms.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright (c) 2016 by Adam Hellberg and Brandon Scott.</copyright>
     <tags>Razer Chroma Corale WinForms Colore</tags>
     <dependencies>
-      <dependency id="Colore" />
+      <dependency id="Colore" version="COLORE_VERSION" />
     </dependencies>
   </metadata>
 </package>

--- a/Corale.Colore.Wpf/Corale.Colore.Wpf.nuspec
+++ b/Corale.Colore.Wpf/Corale.Colore.Wpf.nuspec
@@ -13,7 +13,7 @@
     <copyright>Copyright (c) 2016 by Adam Hellberg and Brandon Scott.</copyright>
     <tags>Razer Chroma Corale WPF Colore</tags>
     <dependencies>
-      <dependency id="Colore" />
+      <dependency id="Colore" version="COLORE_VERSION" />
     </dependencies>
   </metadata>
 </package>

--- a/set_version.ps1
+++ b/set_version.ps1
@@ -68,6 +68,20 @@ function Update-File
     Out-File $file
 }
 
+function Update-NuSpec
+{
+    Param([String]$file)
+
+    Write-Host "Updating Colore depend version in file $file"
+
+    (Get-Content $file) `
+        -replace 'COLORE_VERSION', "$friendlyVersion" |
+    Out-File $file
+}
+
 Update-File Corale.Colore/Properties/AssemblyInfo.cs
 Update-File Corale.Colore.Wpf/Properties/AssemblyInfo.cs
 Update-File Corale.Colore.WinForms/Properties/AssemblyInfo.cs
+
+Update-NuSpec Corale.Colore.Wpf/Corale.Colore.Wpf.nuspec
+Update-NuSpec Corale.Colore.WinForms/Corale.Colore.WinForms.nuspec


### PR DESCRIPTION
Newer version of NuGet assumes lowest version of a package when the
version string is left out for some reason.