### PR TITLE
Swap backslash and forward slash name to be correct

### DIFF
--- a/Corale.Colore/Razer/Keyboard/Key.cs
+++ b/Corale.Colore/Razer/Keyboard/Key.cs
@@ -660,11 +660,11 @@ namespace Corale.Colore.Razer.Keyboard
         OemRightBracket = 0x020D,
 
         /// <summary>
-        /// Forwards slash (/) key.
+        /// Backslash (\) key.
         /// </summary>
         [PublicAPI]
         [UnsafeKey]
-        OemSlash = 0x020E,
+        OemBackslash = 0x020E,
 
         /// <summary>
         /// Semi-colon (;) key.
@@ -691,10 +691,10 @@ namespace Corale.Colore.Razer.Keyboard
         OemPeriod = 0x040B,
 
         /// <summary>
-        /// Backslash (\) key.
+        /// Forwards slash (/) key.
         /// </summary>
         [PublicAPI]
-        OemBackslash = 0x040C,
+        OemSlash = 0x040C,
 
         /// <summary>
         /// Pound sign (#) key.


### PR DESCRIPTION
This PR switches the names of OemBackslash and OemSlash.
I noticed they are wrong as I tried to light up the Slash Key but the wrong Key was lighting up.

Slash:
Previous position: Row 3
New position: Row 5

Backslash:
Previous position: Row 5
New position: Row 3