### PR TITLE
Fix Keyboard.Custom.Clone to make sure Colors for Keys are cloned with the Key Flag

### DIFF
--- a/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
+++ b/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
@@ -354,7 +354,8 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
             var original = new Custom(Color.Red)
             {
                 [Key.A] = Color.Green,
-                [0, 0] = Color.Orange
+                [Key.Escape] = Color.Orange,
+                [0, 1] = Color.Orange
             };
             var clone = original.Clone();
 

--- a/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
+++ b/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
@@ -26,6 +26,7 @@
 namespace Corale.Colore.Tests.Razer.Keyboard.Effects
 {
     using System;
+    using System.Reflection;
 
     using Corale.Colore.Core;
     using Corale.Colore.Razer.Keyboard;
@@ -351,10 +352,34 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
         [Test]
         public void ClonedStructShouldBeIdentical()
         {
-            var original = new Custom(Color.Red);
+            var original = new Custom(Color.Red)
+            {
+                [Key.A] = Color.Green,
+                [0, 0] = Color.Orange
+            };
             var clone = original.Clone();
 
             Assert.That(clone, Is.EqualTo(original));
+
+            var comparePrivateFields = new[]
+            {
+                typeof(Custom).GetField("_colors", BindingFlags.NonPublic | BindingFlags.Instance),
+                typeof(Custom).GetField("_keys", BindingFlags.NonPublic | BindingFlags.Instance)
+            };
+
+            foreach (var compareField in comparePrivateFields)
+            {
+                var originalValue = compareField.GetValue(original) as Color[];
+                var cloneValue = compareField.GetValue(clone) as Color[];
+                Assert.NotNull(originalValue);
+                Assert.NotNull(cloneValue);
+                Assert.That(originalValue.Length, Is.EqualTo(cloneValue.Length));
+
+                for (var index = 0; index < originalValue.Length; index++)
+                {
+                    Assert.That(cloneValue[index].Value, Is.EqualTo(originalValue[index].Value));
+                }
+            }
         }
 
         [Test]

--- a/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
+++ b/Corale.Colore.Tests/Razer/Keyboard/Effects/CustomTests.cs
@@ -26,7 +26,6 @@
 namespace Corale.Colore.Tests.Razer.Keyboard.Effects
 {
     using System;
-    using System.Reflection;
 
     using Corale.Colore.Core;
     using Corale.Colore.Razer.Keyboard;
@@ -360,26 +359,6 @@ namespace Corale.Colore.Tests.Razer.Keyboard.Effects
             var clone = original.Clone();
 
             Assert.That(clone, Is.EqualTo(original));
-
-            var comparePrivateFields = new[]
-            {
-                typeof(Custom).GetField("_colors", BindingFlags.NonPublic | BindingFlags.Instance),
-                typeof(Custom).GetField("_keys", BindingFlags.NonPublic | BindingFlags.Instance)
-            };
-
-            foreach (var compareField in comparePrivateFields)
-            {
-                var originalValue = compareField.GetValue(original) as Color[];
-                var cloneValue = compareField.GetValue(clone) as Color[];
-                Assert.NotNull(originalValue);
-                Assert.NotNull(cloneValue);
-                Assert.That(originalValue.Length, Is.EqualTo(cloneValue.Length));
-
-                for (var index = 0; index < originalValue.Length; index++)
-                {
-                    Assert.That(cloneValue[index].Value, Is.EqualTo(originalValue[index].Value));
-                }
-            }
         }
 
         [Test]

--- a/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
@@ -86,7 +86,11 @@ namespace Corale.Colore.Razer.Keyboard.Effects
             for (var index = 0; index < Constants.MaxKeys; index++)
             {
                 _colors[index] = other[index];
-                _keys[index] = other[(Key)index];
+                var otherKeyColor = other[(Key)index];
+                if (otherKeyColor.Value > 0)
+                {
+                    _keys[index] = Constants.KeyFlag | otherKeyColor;
+                }
             }
         }
 

--- a/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
@@ -85,12 +85,8 @@ namespace Corale.Colore.Razer.Keyboard.Effects
 
             for (var index = 0; index < Constants.MaxKeys; index++)
             {
-                _colors[index] = other[index];
-                var otherKeyColor = other[(Key)index];
-                if (otherKeyColor.Value > 0)
-                {
-                    _keys[index] = Constants.KeyFlag | otherKeyColor;
-                }
+                _colors[index] = other._colors[index];
+                _keys[index] = other._keys[index];
             }
         }
 

--- a/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
+++ b/Corale.Colore/Razer/Keyboard/Effects/Custom.cs
@@ -311,7 +311,7 @@ namespace Corale.Colore.Razer.Keyboard.Effects
         {
             for (var index = 0; index < Constants.MaxKeys; index++)
             {
-                if (this[index] != other[index] || this[(Key)index] != other[(Key)index])
+                if (this._colors[index] != other._colors[index] || this._keys[index] != other._keys[index])
                     return false;
             }
 


### PR DESCRIPTION
This PR fixes Custom.Clone for Keyboard.
Right now the following won't work:
``` c#
	var original = new Corale.Colore.Razer.Keyboard.Effects.Custom(Color.Red)
	{
		[Corale.Colore.Razer.Keyboard.Key.A] = Color.Green,
		[0, 0] = Color.Orange
	};
	var c2 = original.Clone();
	Chroma.Instance.Keyboard.SetCustom(c2);
```
as it will set everything to red and Key.A will also be red.
Reason is that the clone function sets:
``` c#
_keys[index] = other[(Key)index];
```
While Custom[index] will return the Color without the Key-Flag.
The solution is to always add the Key-Flag to the Value if there is a color set ( Value > 0 )

I also made the Test more "usefull" by checking the private Fields via Reflection if they are 100% equal.