### PR TITLE
Remove legacy frameworks from targets

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.0.0",
+      "version": "1.2.0",
       "commands": [
         "dotnet-cake"
       ]
     },
     "gitversion.tool": {
-      "version": "5.6.6",
+      "version": "5.7.0",
       "commands": [
         "dotnet-gitversion"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -11,9 +11,6 @@ indent_style = tab
 [*.{csproj,yml,yaml,json,xml,nuspec,toml}]
 indent_size = 2
 
-[packages.config]
-indent_size = 2
-
 [*.md]
 trim_trailing_whitespace = false
 indent_size = 2

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,5 +13,6 @@
 
   <PropertyGroup>
     <!-- <WarningsAsErrors>8600,8602,8603,8604,8614,8618,8619,8625,8632</WarningsAsErrors> -->
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
   </PropertyGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   github_access_token:
-    secure: REm65Z5Fp9idcP8KKLp06b33/PES+jiRxNAc7ZalS7jHR6i1iCrgxBVcm42Lpvbd
+    secure: sNbY3i/5Yvdl9K+elyCNoCbZj+pdJ9EmeyxPg0KcIY57BlJ6gQ4pwsQKkb45rgoV
 
 cache:
   - tools -> build.cake
@@ -60,14 +60,14 @@ deploy:
   username: Sharparam
   skip_symbols: true
   api_key:
-    secure: REm65Z5Fp9idcP8KKLp06b33/PES+jiRxNAc7ZalS7jHR6i1iCrgxBVcm42Lpvbd
+    secure: sNbY3i/5Yvdl9K+elyCNoCbZj+pdJ9EmeyxPg0KcIY57BlJ6gQ4pwsQKkb45rgoV
   artifact: NuGet
   on:
     appveyor_repo_tag: true
 - provider: GitHub
   description: Automatically created by AppVeyor.
   auth_token:
-    secure: REm65Z5Fp9idcP8KKLp06b33/PES+jiRxNAc7ZalS7jHR6i1iCrgxBVcm42Lpvbd
+    secure: sNbY3i/5Yvdl9K+elyCNoCbZj+pdJ9EmeyxPg0KcIY57BlJ6gQ4pwsQKkb45rgoV
   artifact: NuGet,Archive,OpenCover,Coverage
   draft: true
   on:
@@ -78,7 +78,7 @@ deploy:
   username: Sharparam
   skip_symbols: true
   api_key:
-    secure: REm65Z5Fp9idcP8KKLp06b33/PES+jiRxNAc7ZalS7jHR6i1iCrgxBVcm42Lpvbd
+    secure: sNbY3i/5Yvdl9K+elyCNoCbZj+pdJ9EmeyxPg0KcIY57BlJ6gQ4pwsQKkb45rgoV
   artifact: NuGet
   on:
     branch: develop

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ init:
   - ps: Add-Content -Path "$HOME\.git-credentials" -Value "https://$($env:github_access_token):x-oauth-basic@github.com`n" -NoNewline
 
 install:
-  - choco install docfx -y --version=2.56.6
+  - choco install docfx -y --version=2.58.4
   - dotnet tool restore
 
 build_script:

--- a/build.cake
+++ b/build.cake
@@ -1,10 +1,8 @@
-#module nuget:?package=Cake.DotNetTool.Module&version=1.0.1
+#addin nuget:?package=Cake.DocFx&version=1.0.0
+#addin nuget:?package=Cake.Codecov&version=1.0.1
 
-#addin nuget:?package=Cake.DocFx&version=0.13.1
-#addin nuget:?package=Cake.Codecov&version=1.0.0
-
-#tool dotnet:?package=GitVersion.Tool&version=5.6.3
-#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=4.8.6
+#tool dotnet:?package=GitVersion.Tool&version=5.7.0
+#tool dotnet:?package=dotnet-reportgenerator-globaltool&version=4.8.13
 #tool nuget:?package=Codecov&version=1.13.0
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -206,11 +204,11 @@ Task("Test")
 
         if (AppVeyor.IsRunningOnAppVeyor)
         {
-            settings.Logger = "AppVeyor";
+            settings.Loggers = new[] { "AppVeyor" };
         }
         else
         {
-            settings.Logger = "nunit";
+            settings.Logger = new[] { "nunit" };
         }
 
         DotNetCoreTest(testProject, settings);

--- a/build.cake
+++ b/build.cake
@@ -208,7 +208,7 @@ Task("Test")
         }
         else
         {
-            settings.Logger = new[] { "nunit" };
+            settings.Loggers = new[] { "nunit" };
         }
 
         DotNetCoreTest(testProject, settings);

--- a/src/Colore/Api/ApiException.cs
+++ b/src/Colore/Api/ApiException.cs
@@ -27,10 +27,7 @@ namespace Colore.Api
 {
     using System;
     using System.ComponentModel;
-
-#if NET452 || NETSTANDARD2_1
     using System.Runtime.Serialization;
-#endif
 
     using Colore.Data;
 
@@ -40,9 +37,7 @@ namespace Colore.Api
     /// <summary>
     /// Thrown when a cal to an API function fails.
     /// </summary>
-#if NET452 || NETSTANDARD2_1
     [Serializable]
-#endif
     public class ApiException : ColoreException
     {
         /// <inheritdoc />
@@ -89,7 +84,6 @@ namespace Colore.Api
             Result = result;
         }
 
-#if NET452 || NETSTANDARD2_1
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiException" /> class with serialized data.
         /// </summary>
@@ -115,7 +109,6 @@ namespace Colore.Api
 
             Result = info.GetInt32($"{nameof(ApiException)}.{nameof(Result)}");
         }
-#endif
 
         /// <summary>
         /// Gets the result code returned by the SDK.
@@ -123,7 +116,6 @@ namespace Colore.Api
         [PublicAPI]
         public int Result { get; }
 
-#if NET452 || NETSTANDARD2_1
         /// <summary>
         /// When overridden in a derived class, sets the <see cref="SerializationInfo" /> with information about the exception.
         /// </summary>
@@ -147,6 +139,5 @@ namespace Colore.Api
 
             info.AddValue($"{nameof(ApiException)}.{nameof(Result)}", Result);
         }
-#endif
     }
 }

--- a/src/Colore/Colore.csproj
+++ b/src/Colore/Colore.csproj
@@ -52,12 +52,6 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2020.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.0.0">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/src/Colore/Colore.csproj
+++ b/src/Colore/Colore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard1.3;net452</TargetFrameworks>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <Platforms>AnyCPU</Platforms>
     <Version>$(AssemblyVersion)</Version>
     <DebugType>portable</DebugType>

--- a/src/Colore/Colore.csproj
+++ b/src/Colore/Colore.csproj
@@ -21,7 +21,7 @@
     <WarningsAsErrors />
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard2.1'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <DefineConstants>LIBLOG_PORTABLE</DefineConstants>
   </PropertyGroup>
 
@@ -58,22 +58,13 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3' Or '$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Reflection" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
+    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.7.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/src/Colore/ColoreException.cs
+++ b/src/Colore/ColoreException.cs
@@ -26,9 +26,7 @@
 namespace Colore
 {
     using System;
-#if NET452 || NETSTANDARD2_1
     using System.Runtime.Serialization;
-#endif
 
     using JetBrains.Annotations;
 
@@ -36,9 +34,7 @@ namespace Colore
     /// <summary>
     /// Generic Colore library exception.
     /// </summary>
-#if NET452 || NETSTANDARD2_1
     [Serializable]
-#endif
     public class ColoreException : Exception
     {
         /// <inheritdoc />
@@ -72,7 +68,6 @@ namespace Colore
         {
         }
 
-#if NET452 || NETSTANDARD2_1
         /// <summary>
         /// Initializes a new instance of the <see cref="ColoreException" /> class with serialized data.
         /// </summary>
@@ -92,6 +87,5 @@ namespace Colore
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/src/Colore/Data/DeviceInfo.cs
+++ b/src/Colore/Data/DeviceInfo.cs
@@ -135,13 +135,8 @@ namespace Colore.Data
                 var hashCode = Id.GetHashCode();
                 hashCode = (hashCode * 397) ^ (int)Type;
                 hashCode = (hashCode * 397) ^ Connected.GetHashCode();
-#if NETSTANDARD2_1
                 hashCode = (hashCode * 397) ^ (Name?.GetHashCode(StringComparison.InvariantCulture) ?? 0);
                 hashCode = (hashCode * 397) ^ (Description?.GetHashCode(StringComparison.InvariantCulture) ?? 0);
-#else
-                hashCode = (hashCode * 397) ^ (Name?.GetHashCode() ?? 0);
-                hashCode = (hashCode * 397) ^ (Description?.GetHashCode() ?? 0);
-#endif
                 return hashCode;
             }
         }

--- a/src/Colore/Effects/Keyboard/ExtendedCustomKeyboardEffect.cs
+++ b/src/Colore/Effects/Keyboard/ExtendedCustomKeyboardEffect.cs
@@ -26,7 +26,6 @@
 namespace Colore.Effects.Keyboard
 {
     using System;
-    using System.Diagnostics;
     using System.Runtime.InteropServices;
 
     using Colore.Data;

--- a/src/Colore/Helpers/TaskHelper.cs
+++ b/src/Colore/Helpers/TaskHelper.cs
@@ -35,10 +35,6 @@ namespace Colore.Helpers
         /// <summary>
         /// Gets a "completed task" object.
         /// </summary>
-#if NET452
-        internal static readonly Task CompletedTask = Task.FromResult(0);
-#else
         internal static readonly Task CompletedTask = Task.CompletedTask;
-#endif
     }
 }

--- a/src/Colore/Native/NativeCallException.cs
+++ b/src/Colore/Native/NativeCallException.cs
@@ -27,10 +27,7 @@ namespace Colore.Native
 {
     using System;
     using System.Globalization;
-
-#if NET452 || NETSTANDARD2_1
     using System.Runtime.Serialization;
-#endif
 
     using Colore.Api;
     using Colore.Data;
@@ -42,9 +39,7 @@ namespace Colore.Native
     /// <summary>
     /// Thrown when a native function returns an erroneous result value.
     /// </summary>
-#if NET452 || NETSTANDARD2_1
     [Serializable]
-#endif
     public sealed class NativeCallException : ApiException
     {
         /// <summary>
@@ -64,7 +59,6 @@ namespace Colore.Native
             Function = function;
         }
 
-#if NET452 || NETSTANDARD2_1
         /// <summary>
         /// Initializes a new instance of the <see cref="NativeCallException" /> class with serialized data.
         /// </summary>
@@ -90,7 +84,6 @@ namespace Colore.Native
 
             Function = info.GetString($"{nameof(NativeCallException)}.{nameof(Function)}");
         }
-#endif
 
         /// <summary>
         /// Gets the name of the native function that was called.
@@ -98,7 +91,6 @@ namespace Colore.Native
         [PublicAPI]
         public string Function { get; }
 
-#if NET452 || NETSTANDARD2_1
         /// <summary>
         /// When overridden in a derived class, sets the <see cref="SerializationInfo" /> with information about the exception.
         /// </summary>
@@ -122,7 +114,5 @@ namespace Colore.Native
 
             info.AddValue($"{nameof(NativeCallException)}.{nameof(Function)}", Function);
         }
-#endif
     }
-#pragma warning restore CA1032 // Implement standard exception constructors
 }

--- a/src/Colore/Rest/RestException.cs
+++ b/src/Colore/Rest/RestException.cs
@@ -27,10 +27,7 @@ namespace Colore.Rest
 {
     using System;
     using System.Net;
-
-#if NET452 || NETSTANDARD2_1
     using System.Runtime.Serialization;
-#endif
 
     using Colore.Api;
     using Colore.Data;
@@ -41,9 +38,7 @@ namespace Colore.Rest
     /// <summary>
     /// Represents an error in the Chroma REST API.
     /// </summary>
-#if NET452 || NETSTANDARD2_1
     [Serializable]
-#endif
     public sealed class RestException : ApiException
     {
         /// <inheritdoc />
@@ -100,7 +95,6 @@ namespace Colore.Rest
             RestData = restData;
         }
 
-#if NET452 || NETSTANDARD2_1
         /// <summary>
         /// Initializes a new instance of the <see cref="RestException" /> class with serialized data.
         /// </summary>
@@ -130,7 +124,6 @@ namespace Colore.Rest
             StatusCode = (HttpStatusCode)info.GetInt32($"{nameof(RestException)}.{nameof(StatusCode)}");
             RestData = info.GetString($"{nameof(RestException)}.{nameof(RestData)}");
         }
-#endif
 
         /// <summary>
         /// Gets the <see cref="Uri" /> called which caused the exception.
@@ -152,7 +145,6 @@ namespace Colore.Rest
         [PublicAPI]
         public string RestData { get; }
 
-#if NET452 || NETSTANDARD2_1
         /// <summary>
         /// When overridden in a derived class, sets the <see cref="SerializationInfo" /> with information about the exception.
         /// </summary>
@@ -183,6 +175,5 @@ namespace Colore.Rest
             info.AddValue($"{nameof(RestException)}.{nameof(StatusCode)}", (int)StatusCode);
             info.AddValue($"{nameof(RestException)}.{nameof(RestData)}", RestData);
         }
-#endif
     }
 }

--- a/src/Colore/UnsupportedDeviceException.cs
+++ b/src/Colore/UnsupportedDeviceException.cs
@@ -27,10 +27,7 @@ namespace Colore
 {
     using System;
     using System.Globalization;
-
-#if NET452 || NETSTANDARD2_1
     using System.Runtime.Serialization;
-#endif
 
     using Colore.Implementations;
 
@@ -42,9 +39,7 @@ namespace Colore
     /// Thrown when an invalid <see cref="Guid" /> is passed to the
     /// constructor of <see cref="GenericDeviceImplementation" />.
     /// </summary>
-#if NET452 || NETSTANDARD2_1
     [Serializable]
-#endif
     public sealed class UnsupportedDeviceException : ColoreException
     {
         /// <summary>
@@ -64,7 +59,6 @@ namespace Colore
             DeviceId = deviceId;
         }
 
-#if NET452 || NETSTANDARD2_1
         /// <summary>
         /// Initializes a new instance of the <see cref="UnsupportedDeviceException" /> class with serialized data.
         /// </summary>
@@ -90,7 +84,6 @@ namespace Colore
 
             DeviceId = new Guid(info.GetString($"{nameof(UnsupportedDeviceException)}.{nameof(DeviceId)}"));
         }
-#endif
 
         /// <summary>
         /// Gets the <see cref="Guid" /> of the device.
@@ -98,7 +91,6 @@ namespace Colore
         [PublicAPI]
         public Guid DeviceId { get; }
 
-#if NET452 || NETSTANDARD2_1
         /// <summary>
         /// When overridden in a derived class, sets the <see cref="SerializationInfo" /> with information about the exception.
         /// </summary>
@@ -122,7 +114,5 @@ namespace Colore
 
             info.AddValue($"{nameof(UnsupportedDeviceException)}.{nameof(DeviceId)}", DeviceId.ToString());
         }
-#endif
     }
-#pragma warning restore CA1032 // Implement standard exception constructors
 }

--- a/tests/Colore.Tests/Colore.Tests.csproj
+++ b/tests/Colore.Tests/Colore.Tests.csproj
@@ -15,16 +15,16 @@
 
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.2" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit.Console" Version="3.11.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageReference Include="NunitXml.TestLogger" Version="2.1.62" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit.Console" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="NunitXml.TestLogger" Version="3.0.107" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

<!--- /!\ PLEASE NOTE: /!\ -->
<!--- If your pull request is a FEATURE, it should target the DEVELOP branch -->
<!--- If your pull request is a HOTFIX, it should target the MASTER branch -->
<!--- FEATURES are branched from the DEVELOP branch -->
<!--- HOTFIXES are branched from the MASTER branch --> 

## Description
<!--- Describe your changes in detail -->

Removes old/unsupported frameworks from the list of target frameworks.

⚠️ **This is a breaking change, since previously supported targets are being removed, so this necessitates increasing the major version of Colore to 7.**

Updates #287.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It doesn't make much sense to support these frameworks since they are no longer supported by Microsoft, and they suggest everyone target .NET Standard 2.1 as the lowest.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tests have been run and it has been checked to make sure the project compiles. Since there is no functionality changes I have not tested it against the Razer SDK.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes where applicable.
- [X] All new and existing tests passed.

<!--- You can find a link to the CONTRIBUTING document -->
<!--- near the top of this page. --> 
